### PR TITLE
Add crafting system, inventory management, and forge UI

### DIFF
--- a/src/data/GameStateFactory.ts
+++ b/src/data/GameStateFactory.ts
@@ -1,4 +1,4 @@
-import type { KnightRecord, KnightsState } from "../types/state";
+import type { InventoryItem, InventoryState, KnightRecord, KnightsState } from "../types/state";
 import type { ResourceSnapshot } from "../systems/ResourceManager";
 import type { GameState, QueueItemState } from "../types/state";
 import { cloneBuildingState, createDefaultBuildingState } from "./BuildingState";
@@ -20,6 +20,11 @@ const DEFAULT_QUEUE: QueueItemState[] = [
   }
 ];
 
+const DEFAULT_INVENTORY: InventoryState = {
+  nextInstanceId: 1,
+  items: []
+};
+
 const createDefaultKnightsState = (): KnightsState => ({
   roster: [],
   candidates: [],
@@ -29,7 +34,12 @@ const createDefaultKnightsState = (): KnightsState => ({
 
 const cloneKnightRecord = (knight: KnightRecord): KnightRecord => ({
   ...knight,
-  attributes: { ...knight.attributes }
+  attributes: { ...knight.attributes },
+  equipment: {
+    weaponId: knight.equipment.weaponId,
+    armorId: knight.equipment.armorId,
+    trinketIds: [...knight.equipment.trinketIds]
+  }
 });
 
 const cloneKnightsState = (state: KnightsState): KnightsState => ({
@@ -37,6 +47,17 @@ const cloneKnightsState = (state: KnightsState): KnightsState => ({
   candidates: state.candidates.map(cloneKnightRecord),
   nextId: state.nextId,
   candidateSeed: state.candidateSeed
+});
+
+const cloneInventoryItem = (item: InventoryItem): InventoryItem => ({
+  ...item,
+  affixes: item.affixes ? item.affixes.map((affix) => ({ ...affix })) : [],
+  effects: item.effects.map((effect) => ({ ...effect }))
+});
+
+const cloneInventoryState = (state: InventoryState): InventoryState => ({
+  nextInstanceId: state.nextInstanceId,
+  items: state.items.map(cloneInventoryItem)
 });
 
 /**
@@ -48,6 +69,7 @@ export const createDefaultGameState = (): GameState => ({
   timeScale: 1,
   resources: { ...DEFAULT_RESOURCES },
   queue: DEFAULT_QUEUE.map((item) => ({ ...item })),
+  inventory: cloneInventoryState(DEFAULT_INVENTORY),
   knights: createDefaultKnightsState(),
   buildings: createDefaultBuildingState()
 });
@@ -59,6 +81,7 @@ export const cloneGameState = (state: GameState): GameState => ({
   ...state,
   resources: { ...state.resources },
   queue: state.queue.map((item) => ({ ...item })),
+  inventory: cloneInventoryState(state.inventory),
   knights: cloneKnightsState(state.knights),
   buildings: cloneBuildingState(state.buildings)
 });

--- a/src/scenes/CastleScene.ts
+++ b/src/scenes/CastleScene.ts
@@ -15,6 +15,7 @@ import economySystem from "../systems/EconomySystem";
 import questManager from "../systems/QuestManager";
 import buildingSystem from "../systems/BuildingSystem";
 import resourceManager, { RESOURCE_TYPES, type ResourceType } from "../systems/ResourceManager";
+import inventorySystem from "../systems/InventorySystem";
 import timeSystem from "../systems/TimeSystem";
 import SaveSystem from "../utils/SaveSystem";
 
@@ -164,6 +165,7 @@ export default class CastleScene extends Phaser.Scene {
     timeSystem.setTimeScale(state.timeScale);
 
     resourceManager.initialize({ ...state.resources });
+    inventorySystem.initialize(state.inventory);
     knightManager.initialize(state.knights);
     buildingSystem.initialize(state.buildings);
     economySystem.initialize();
@@ -187,6 +189,7 @@ export default class CastleScene extends Phaser.Scene {
 
     buildingSystem.shutdown();
     economySystem.shutdown();
+    inventorySystem.shutdown();
     knightManager.shutdown();
   }
 

--- a/src/scenes/ui/CraftingPanel.ts
+++ b/src/scenes/ui/CraftingPanel.ts
@@ -1,0 +1,442 @@
+import Phaser from "phaser";
+
+import dataRegistry from "../../systems/DataRegistry";
+import craftingSystem, { type CraftingMaterialInput } from "../../systems/CraftingSystem";
+import inventorySystem from "../../systems/InventorySystem";
+import knightManager from "../../systems/KnightManager";
+import buildingSystem from "../../systems/BuildingSystem";
+import EventBus, { GameEvent } from "../../systems/EventBus";
+import RNG from "../../utils/RNG";
+import type { Recipe } from "../../types/game";
+import type { InventoryItem, KnightRecord } from "../../types/state";
+
+const PANEL_WIDTH = 620;
+const PANEL_HEIGHT = 360;
+const COLUMN_WIDTH = 220;
+const PADDING = 16;
+const PANEL_BACKGROUND = 0x101d33;
+const PANEL_BORDER = 0xffffff;
+const TEXT_COLOR = "#f0f5ff";
+const MUTED_TEXT = "#9aa7c8";
+const BUTTON_IDLE = 0x1f2f4a;
+const BUTTON_HOVER = 0x29415f;
+
+const SLOT_LABELS: Array<{ readonly id: EquipmentSlot; readonly label: string }> = [
+  { id: "weapon", label: "Weapon" },
+  { id: "armor", label: "Armor" },
+  { id: "trinket", label: "Trinket" }
+];
+
+type EquipmentSlot = "weapon" | "armor" | "trinket";
+
+interface ButtonEntry {
+  readonly background: Phaser.GameObjects.Rectangle;
+  readonly label: Phaser.GameObjects.Text;
+}
+
+interface RecipeEntry {
+  readonly recipe: Recipe;
+  readonly text: Phaser.GameObjects.Text;
+}
+
+/**
+ * Interactive panel that surfaces forge recipes and equipment management.
+ */
+export default class CraftingPanel extends Phaser.GameObjects.Container {
+  private readonly recipes: Recipe[];
+  private readonly recipeEntries: RecipeEntry[];
+  private readonly materialsText: Phaser.GameObjects.Text[];
+  private readonly detailText: Phaser.GameObjects.Text;
+  private readonly statusText: Phaser.GameObjects.Text;
+  private readonly forgeButton: ButtonEntry;
+  private readonly equipmentContainer: Phaser.GameObjects.Container;
+  private readonly equipPromptText: Phaser.GameObjects.Text;
+  private readonly slotButtons: Map<EquipmentSlot, ButtonEntry>;
+  private readonly knightListContainer: Phaser.GameObjects.Container;
+  private selectedRecipe?: Recipe;
+  private selectedSlot: EquipmentSlot;
+  private pendingEquip?: InventoryItem;
+  private inventoryListener?: () => void;
+  private knightListener?: () => void;
+
+  public constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y);
+
+    this.recipes = dataRegistry.getRecipes();
+    this.recipeEntries = [];
+    this.materialsText = [];
+    this.slotButtons = new Map();
+    this.selectedSlot = "weapon";
+
+    this.setSize(PANEL_WIDTH, PANEL_HEIGHT);
+    this.setScrollFactor(0);
+
+    const background = scene.add.rectangle(0, 0, PANEL_WIDTH, PANEL_HEIGHT, PANEL_BACKGROUND, 0.9);
+    background.setOrigin(0, 0);
+    background.setStrokeStyle(1, PANEL_BORDER, 0.25);
+
+    const title = scene.add.text(PADDING, PADDING, "Forge & Armory", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "22px",
+      fontStyle: "bold",
+      color: TEXT_COLOR
+    });
+
+    const subtitle = scene.add.text(PADDING, PADDING + 26, "Shape equipment and outfit champions.", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "14px",
+      color: MUTED_TEXT
+    });
+
+    const recipeHeader = scene.add.text(PADDING, PADDING + 58, "Recipes", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "16px",
+      fontStyle: "bold",
+      color: TEXT_COLOR
+    });
+
+    this.detailText = scene.add.text(PADDING + COLUMN_WIDTH + 32, PADDING + 58, "Select a recipe", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "15px",
+      color: TEXT_COLOR,
+      wordWrap: { width: PANEL_WIDTH - COLUMN_WIDTH - 48 }
+    });
+
+    this.statusText = scene.add.text(PADDING, PANEL_HEIGHT - 36, "", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "14px",
+      color: MUTED_TEXT
+    });
+
+    this.forgeButton = this.createButton(
+      PANEL_WIDTH - PADDING - 110,
+      PANEL_HEIGHT - PADDING - 32,
+      120,
+      36,
+      "Forge",
+      () => this.handleForge()
+    );
+
+    this.forgeButton.background.setFillStyle(0x1b2840, 1);
+
+    this.equipmentContainer = scene.add.container(PADDING + COLUMN_WIDTH + 32, PADDING + 160);
+    this.equipPromptText = scene.add.text(
+      PADDING + COLUMN_WIDTH + 32,
+      PADDING + 128,
+      "Inventory",
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "16px",
+        fontStyle: "bold",
+        color: TEXT_COLOR
+      }
+    );
+
+    this.knightListContainer = scene.add.container(PADDING + COLUMN_WIDTH + 320, PADDING + 128);
+
+    this.add([background, title, subtitle, recipeHeader, this.detailText, this.statusText]);
+    this.add(this.forgeButton.background);
+    this.add(this.forgeButton.label);
+    this.add(this.equipPromptText);
+    this.add(this.equipmentContainer);
+    this.add(this.knightListContainer);
+
+    this.buildRecipeList();
+    this.buildSlotButtons();
+    this.refreshMaterials();
+    this.refreshInventory();
+    this.registerEvents();
+  }
+
+  public override destroy(fromScene?: boolean): void {
+    this.unregisterEvents();
+    this.recipeEntries.forEach((entry) => entry.text.destroy());
+    this.materialsText.forEach((text) => text.destroy());
+    this.forgeButton.background.destroy();
+    this.forgeButton.label.destroy();
+    this.equipmentContainer.destroy(true);
+    this.knightListContainer.destroy(true);
+    this.equipPromptText.destroy();
+    super.destroy(fromScene);
+  }
+
+  private createButton(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    label: string,
+    onClick: () => void
+  ): ButtonEntry {
+    const background = this.scene.add.rectangle(x, y, width, height, BUTTON_IDLE, 1);
+    background.setOrigin(0.5);
+    background.setStrokeStyle(1, PANEL_BORDER, 0.25);
+    background.setInteractive({ useHandCursor: true });
+
+    const text = this.scene.add.text(x, y, label, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "16px",
+      color: TEXT_COLOR
+    });
+    text.setOrigin(0.5);
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OVER, () => {
+      background.setFillStyle(BUTTON_HOVER, 1);
+    });
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OUT, () => {
+      background.setFillStyle(BUTTON_IDLE, 1);
+    });
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, onClick);
+
+    return { background, label: text };
+  }
+
+  private buildRecipeList(): void {
+    const startY = PADDING + 92;
+    const lineHeight = 26;
+
+    this.recipes.forEach((recipe, index) => {
+      const text = this.scene.add.text(PADDING, startY + index * lineHeight, recipe.name, {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "15px",
+        color: MUTED_TEXT
+      });
+      text.setInteractive({ useHandCursor: true });
+      text.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => this.selectRecipe(recipe));
+      text.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OVER, () => {
+        if (this.selectedRecipe !== recipe) {
+          text.setColor(TEXT_COLOR);
+        }
+      });
+      text.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OUT, () => {
+        if (this.selectedRecipe !== recipe) {
+          text.setColor(MUTED_TEXT);
+        }
+      });
+      this.add(text);
+      this.recipeEntries.push({ recipe, text });
+    });
+  }
+
+  private buildSlotButtons(): void {
+    const baseX = PADDING + COLUMN_WIDTH + 32;
+    const baseY = PANEL_HEIGHT - 96;
+    const spacing = 84;
+
+    SLOT_LABELS.forEach((slot, index) => {
+      const button = this.createButton(baseX + index * spacing, baseY, 76, 30, slot.label, () => {
+        this.selectedSlot = slot.id;
+        this.updateSlotHighlights();
+      });
+      this.add(button.background);
+      this.add(button.label);
+      this.slotButtons.set(slot.id, button);
+    });
+
+    this.updateSlotHighlights();
+  }
+
+  private updateSlotHighlights(): void {
+    this.slotButtons.forEach((button, slot) => {
+      const active = slot === this.selectedSlot;
+      button.background.setFillStyle(active ? 0x3661a2 : BUTTON_IDLE, 1);
+      button.label.setColor(active ? "#fdfcff" : TEXT_COLOR);
+    });
+  }
+
+  private selectRecipe(recipe: Recipe): void {
+    this.selectedRecipe = recipe;
+    this.recipeEntries.forEach((entry) => {
+      entry.text.setColor(entry.recipe === recipe ? TEXT_COLOR : MUTED_TEXT);
+      entry.text.setFontStyle(entry.recipe === recipe ? "bold" : "normal");
+    });
+
+    this.detailText.setText(`${recipe.description}\nCrafting Time: ${recipe.craftingTimeHours}h`);
+    this.refreshMaterials();
+  }
+
+  private refreshMaterials(): void {
+    this.materialsText.forEach((text) => text.destroy());
+    this.materialsText.length = 0;
+
+    const recipe = this.selectedRecipe;
+    if (!recipe) {
+      this.updateForgeButton(false);
+      return;
+    }
+
+    const startX = PADDING + COLUMN_WIDTH + 32;
+    let offsetY = PADDING + 100;
+
+    const inventory = inventorySystem.getSnapshot();
+    const materialCounts = new Map<string, number>();
+    inventory.items
+      .filter((item) => item.itemType === "material")
+      .forEach((item) => {
+        const current = materialCounts.get(item.baseItemId) ?? 0;
+        materialCounts.set(item.baseItemId, current + item.quantity);
+      });
+
+    let canForge = true;
+    recipe.ingredients.forEach((ingredient) => {
+      const available = materialCounts.get(ingredient.itemId) ?? 0;
+      const requirementText = `${ingredient.quantity}x ${this.getItemName(ingredient.itemId)} (Have ${available})`;
+      const text = this.scene.add.text(startX, offsetY, requirementText, {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: available >= ingredient.quantity ? TEXT_COLOR : "#ff6b6b"
+      });
+      this.add(text);
+      this.materialsText.push(text);
+      offsetY += 20;
+      if (available < ingredient.quantity) {
+        canForge = false;
+      }
+    });
+
+    this.updateForgeButton(canForge);
+  }
+
+  private updateForgeButton(enabled: boolean): void {
+    this.forgeButton.background.disableInteractive();
+    if (enabled) {
+      this.forgeButton.background.setInteractive({ useHandCursor: true });
+      this.forgeButton.background.setFillStyle(BUTTON_IDLE, 1);
+      this.forgeButton.label.setColor(TEXT_COLOR);
+    } else {
+      this.forgeButton.background.setFillStyle(0x121b2e, 1);
+      this.forgeButton.label.setColor(MUTED_TEXT);
+    }
+  }
+
+  private handleForge(): void {
+    const recipe = this.selectedRecipe;
+    if (!recipe) {
+      this.statusText.setText("Select a recipe to begin forging.");
+      return;
+    }
+
+    const requirements: CraftingMaterialInput[] = recipe.ingredients.map((ingredient) => ({
+      itemId: ingredient.itemId,
+      quantity: ingredient.quantity
+    }));
+
+    const consumed = inventorySystem.consumeMaterials(requirements);
+    if (!consumed) {
+      this.statusText.setText("Insufficient materials in the vault.");
+      return;
+    }
+
+    try {
+      const smithLevel = buildingSystem.getState().levels.Forge ?? 1;
+      const seed = Date.now() + recipe.id.length * 17;
+      const forgedItem = craftingSystem.craft(recipe.id, requirements, smithLevel, new RNG(seed));
+      const stored = inventorySystem.addItem({ ...forgedItem, itemType: "equipment" });
+      this.statusText.setText(`Crafted ${stored.name} (${stored.quality ?? "standard"}).`);
+      this.pendingEquip = stored;
+      this.refreshMaterials();
+      this.refreshInventory();
+      this.refreshKnightList();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Forge attempt failed.";
+      this.statusText.setText(message);
+    }
+  }
+
+  private refreshInventory(): void {
+    this.equipmentContainer.removeAll(true);
+    const items = inventorySystem.getItemsByType("equipment");
+    const lineHeight = 22;
+    items.slice(0, 6).forEach((item, index) => {
+      const nameText = this.scene.add.text(0, index * lineHeight, this.describeItem(item), {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: TEXT_COLOR
+      });
+
+      nameText.setInteractive({ useHandCursor: true });
+      nameText.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => {
+        this.pendingEquip = item;
+        this.statusText.setText(`Selected ${item.name} for equipping.`);
+        this.refreshKnightList();
+      });
+
+      this.equipmentContainer.add(nameText);
+    });
+  }
+
+  private describeItem(item: InventoryItem): string {
+    const quality = item.quality ? `${item.quality}` : "standard";
+    const rarity = item.rarity;
+    return `${item.name} [${quality} / ${rarity}]`;
+  }
+
+  private refreshKnightList(): void {
+    this.knightListContainer.removeAll(true);
+    const pending = this.pendingEquip;
+    this.equipPromptText.setText(pending ? `Equip ${pending.name}` : "Inventory");
+    if (!pending) {
+      return;
+    }
+
+    const knights = knightManager.getRoster();
+    const lineHeight = 22;
+    knights.forEach((knight, index) => {
+      const text = this.scene.add.text(0, index * lineHeight, this.formatKnightEntry(knight), {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: TEXT_COLOR
+      });
+      text.setInteractive({ useHandCursor: true });
+      text.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => {
+        const success = knightManager.equipItem(knight.id, this.selectedSlot, pending.instanceId);
+        this.statusText.setText(
+          success
+            ? `Equipped ${pending.name} to ${knight.name} (${this.selectedSlot}).`
+            : `Unable to equip ${pending.name} on ${knight.name}.`
+        );
+        if (success) {
+          this.pendingEquip = undefined;
+          this.refreshInventory();
+          this.refreshKnightList();
+        }
+      });
+      this.knightListContainer.add(text);
+    });
+  }
+
+  private formatKnightEntry(knight: KnightRecord): string {
+    const power = knightManager.getPowerScore(knight);
+    return `${knight.name} "${knight.epithet}" [${knight.profession}] Power ${power}`;
+  }
+
+  private getItemName(itemId: string): string {
+    const definition = dataRegistry.getItemById(itemId);
+    return definition ? definition.name : itemId;
+  }
+
+  private registerEvents(): void {
+    this.inventoryListener = () => {
+      this.refreshMaterials();
+      this.refreshInventory();
+      this.refreshKnightList();
+    };
+    this.knightListener = () => {
+      this.refreshKnightList();
+    };
+
+    EventBus.on(GameEvent.InventoryUpdated, this.inventoryListener, this);
+    EventBus.on(GameEvent.KnightStateUpdated, this.knightListener, this);
+  }
+
+  private unregisterEvents(): void {
+    if (this.inventoryListener) {
+      EventBus.off(GameEvent.InventoryUpdated, this.inventoryListener, this);
+      this.inventoryListener = undefined;
+    }
+    if (this.knightListener) {
+      EventBus.off(GameEvent.KnightStateUpdated, this.knightListener, this);
+      this.knightListener = undefined;
+    }
+  }
+}

--- a/src/systems/CraftingSystem.ts
+++ b/src/systems/CraftingSystem.ts
@@ -1,0 +1,238 @@
+import dataRegistry from "./DataRegistry";
+import type { ItemAffix, ItemQuality, ItemRarity, Recipe } from "../types/game";
+import type { InventoryItem } from "../types/state";
+import RNG from "../utils/RNG";
+
+interface CraftingMaterialInput {
+  readonly itemId: string;
+  readonly quantity: number;
+}
+
+interface QualityWeight {
+  readonly quality: ItemQuality;
+  readonly weight: number;
+}
+
+interface RarityUpgradeStep {
+  readonly threshold: number;
+  readonly increase: number;
+}
+
+interface AffixDefinition {
+  readonly id: string;
+  readonly label: string;
+  readonly stat: ItemAffix["stat"];
+  readonly min: number;
+  readonly max: number;
+  readonly weight: number;
+}
+
+const QUALITY_WEIGHTS: QualityWeight[] = [
+  { quality: "crude", weight: 40 },
+  { quality: "standard", weight: 35 },
+  { quality: "fine", weight: 20 },
+  { quality: "masterwork", weight: 5 }
+];
+
+const QUALITY_LABEL: Record<ItemQuality, string> = {
+  crude: "Crude",
+  standard: "Tempered",
+  fine: "Refined",
+  masterwork: "Mythic"
+};
+
+const QUALITY_VALUE_MULTIPLIER: Record<ItemQuality, number> = {
+  crude: 0.8,
+  standard: 1,
+  fine: 1.35,
+  masterwork: 1.8
+};
+
+const QUALITY_AFFIX_COUNT: Record<ItemQuality, number> = {
+  crude: 0,
+  standard: 1,
+  fine: 2,
+  masterwork: 3
+};
+
+const RARITY_ORDER: ItemRarity[] = ["common", "uncommon", "rare", "legendary"];
+
+const RARITY_UPGRADE_STEPS: RarityUpgradeStep[] = [
+  { threshold: 0.25, increase: 1 },
+  { threshold: 0.6, increase: 1 }
+];
+
+const AFFIX_POOL: AffixDefinition[] = [
+  { id: "str", label: "Might", stat: "strength", min: 2, max: 6, weight: 40 },
+  { id: "int", label: "Wisdom", stat: "intellect", min: 2, max: 6, weight: 40 },
+  { id: "vit", label: "Vitality", stat: "vitality", min: 3, max: 8, weight: 30 }
+];
+
+const AFFIX_PREFIX: Record<ItemAffix["stat"], string> = {
+  strength: "Mighty",
+  intellect: "Sage's",
+  vitality: "Stalwart"
+};
+
+/**
+ * Simulation responsible for transforming materials into crafted gear.
+ */
+class CraftingSystem {
+  /**
+   * Forges an item based on the provided recipe and smith expertise.
+   */
+  public craft(
+    recipeId: string,
+    materials: ReadonlyArray<CraftingMaterialInput>,
+    smithLevel: number,
+    rng: RNG
+  ): InventoryItem {
+    const recipe = this.getRecipe(recipeId);
+    this.ensureRequirementsMet(recipe, materials);
+
+    const resultDefinition = dataRegistry.getItemById(recipe.result.itemId);
+    if (!resultDefinition) {
+      throw new Error(`Unknown item definition ${recipe.result.itemId}`);
+    }
+
+    const quality = this.rollQuality(smithLevel, rng);
+    const rarity = this.rollRarity(resultDefinition.rarity, quality, smithLevel, rng);
+    const affixes = this.rollAffixes(quality, smithLevel, rng);
+    const quantity = Math.max(1, recipe.result.quantity ?? 1);
+    const prefix = affixes.length > 0 ? `${AFFIX_PREFIX[affixes[0]!.stat]} ` : "";
+    const name = `${prefix}${QUALITY_LABEL[quality]} ${resultDefinition.name}`.replace(/\s+/g, " ").trim();
+
+    const forged: InventoryItem = {
+      id: resultDefinition.id,
+      baseItemId: resultDefinition.id,
+      name,
+      description: `${resultDefinition.description}\nForged with ${QUALITY_LABEL[quality]} craftsmanship.`,
+      rarity,
+      value: Math.round(resultDefinition.value * QUALITY_VALUE_MULTIPLIER[quality]),
+      tags: [...resultDefinition.tags],
+      effects: resultDefinition.effects.map((effect) => ({ ...effect })),
+      quality,
+      affixes,
+      quantity,
+      itemType: "equipment",
+      instanceId: ""
+    };
+
+    return forged;
+  }
+
+  private getRecipe(recipeId: string): Recipe {
+    const recipe = dataRegistry.getRecipeById(recipeId);
+    if (!recipe) {
+      throw new Error(`Unknown recipe ${recipeId}`);
+    }
+    return recipe;
+  }
+
+  private ensureRequirementsMet(recipe: Recipe, materials: ReadonlyArray<CraftingMaterialInput>): void {
+    const aggregated = new Map<string, number>();
+    materials.forEach((material) => {
+      const current = aggregated.get(material.itemId) ?? 0;
+      aggregated.set(material.itemId, current + material.quantity);
+    });
+
+    const missing = recipe.ingredients.filter((ingredient) => {
+      const provided = aggregated.get(ingredient.itemId) ?? 0;
+      return provided < ingredient.quantity;
+    });
+
+    if (missing.length > 0) {
+      throw new Error(`Insufficient materials for recipe ${recipe.id}`);
+    }
+  }
+
+  private rollQuality(smithLevel: number, rng: RNG): ItemQuality {
+    const bonus = Math.max(0, Math.floor(smithLevel));
+    const adjusted = QUALITY_WEIGHTS.map((entry, index) => {
+      const multiplier = 1 + bonus * (index / QUALITY_WEIGHTS.length) * 0.15;
+      return { value: entry.quality, weight: entry.weight * multiplier };
+    });
+
+    return this.pickWeightedValue(adjusted, rng);
+  }
+
+  private rollRarity(
+    baseRarity: ItemRarity,
+    quality: ItemQuality,
+    smithLevel: number,
+    rng: RNG
+  ): ItemRarity {
+    let index = RARITY_ORDER.indexOf(baseRarity);
+    const qualityBonus = quality === "masterwork" ? 0.25 : quality === "fine" ? 0.1 : 0;
+    const skillBonus = Math.min(0.35, smithLevel * 0.05);
+    const chance = qualityBonus + skillBonus;
+
+    RARITY_UPGRADE_STEPS.forEach((step) => {
+      if (index < RARITY_ORDER.length - 1 && rng.next() < Math.max(0.05, chance - step.threshold)) {
+        index = Math.min(RARITY_ORDER.length - 1, index + step.increase);
+      }
+    });
+
+    return RARITY_ORDER[index] ?? baseRarity;
+  }
+
+  private rollAffixes(quality: ItemQuality, smithLevel: number, rng: RNG): ItemAffix[] {
+    const baseCount = QUALITY_AFFIX_COUNT[quality];
+    const bonus = Math.max(0, Math.floor(smithLevel / 4));
+    const targetCount = Math.min(AFFIX_POOL.length, baseCount + bonus);
+    if (targetCount === 0) {
+      return [];
+    }
+
+    const available = [...AFFIX_POOL];
+    const affixes: ItemAffix[] = [];
+    for (let i = 0; i < targetCount; i += 1) {
+      if (available.length === 0) {
+        break;
+      }
+
+      const affixDefinition = this.pickWeightedValue(
+        available.map((entry) => ({ value: entry, weight: entry.weight })),
+        rng
+      );
+      const index = available.findIndex((entry) => entry.id === affixDefinition.id);
+      if (index >= 0) {
+        available.splice(index, 1);
+      }
+      const valueRange = affixDefinition.max - affixDefinition.min;
+      const rolledValue = affixDefinition.min + Math.round(rng.next() * valueRange);
+      const affix: ItemAffix = {
+        id: `${affixDefinition.id}-${i}`,
+        label: `${affixDefinition.label} +${rolledValue}`,
+        stat: affixDefinition.stat,
+        value: rolledValue
+      };
+      affixes.push(affix);
+    }
+
+    return affixes;
+  }
+
+  private pickWeightedValue<T>(entries: Array<{ value: T; weight: number }>, rng: RNG): T {
+    const totalWeight = entries.reduce((sum, entry) => sum + Math.max(0, entry.weight), 0);
+    if (totalWeight <= 0) {
+      return entries[0]!.value;
+    }
+
+    const threshold = rng.next() * totalWeight;
+    let accumulator = 0;
+    for (const entry of entries) {
+      accumulator += Math.max(0, entry.weight);
+      if (threshold <= accumulator) {
+        return entry.value;
+      }
+    }
+
+    return entries[entries.length - 1]!.value;
+  }
+}
+
+const craftingSystem = new CraftingSystem();
+
+export default craftingSystem;
+export type { CraftingMaterialInput };

--- a/src/systems/DataRegistry.ts
+++ b/src/systems/DataRegistry.ts
@@ -196,15 +196,57 @@ class DataRegistry {
     const tags = record.tags;
     const effects = record.effects;
 
-    return (
-      this.isNonEmptyString(id) &&
-      this.isNonEmptyString(name) &&
-      this.isNonEmptyString(description) &&
-      this.isItemRarity(rarity) &&
-      this.isNumber(valueAmount) &&
-      this.isStringArray(tags) &&
-      this.isResourceDeltaArray(effects)
-    );
+    const quality = record.quality;
+    const affixes = record.affixes;
+    const instanceId = record.instanceId;
+    const baseItemId = record.baseItemId;
+    const quantity = record.quantity;
+    const itemType = record.itemType;
+    const equippedBy = record.equippedBy;
+
+    if (
+      !(
+        this.isNonEmptyString(id) &&
+        this.isNonEmptyString(name) &&
+        this.isNonEmptyString(description) &&
+        this.isItemRarity(rarity) &&
+        this.isNumber(valueAmount) &&
+        this.isStringArray(tags) &&
+        this.isResourceDeltaArray(effects)
+      )
+    ) {
+      return false;
+    }
+
+    if (quality !== undefined && !this.isItemQuality(quality)) {
+      return false;
+    }
+
+    if (affixes !== undefined && !this.isItemAffixArray(affixes)) {
+      return false;
+    }
+
+    if (instanceId !== undefined && !this.isNonEmptyString(instanceId)) {
+      return false;
+    }
+
+    if (baseItemId !== undefined && !this.isNonEmptyString(baseItemId)) {
+      return false;
+    }
+
+    if (quantity !== undefined && !this.isNumber(quantity)) {
+      return false;
+    }
+
+    if (itemType !== undefined && itemType !== "equipment" && itemType !== "material") {
+      return false;
+    }
+
+    if (equippedBy !== undefined && !this.isNonEmptyString(equippedBy)) {
+      return false;
+    }
+
+    return true;
   }
 
   private isRecipe(value: unknown): value is Recipe {
@@ -494,6 +536,39 @@ class DataRegistry {
 
   private isItemRarity(value: unknown): value is Item["rarity"] {
     return value === "common" || value === "uncommon" || value === "rare" || value === "legendary";
+  }
+
+  private isItemQuality(value: unknown): value is NonNullable<Item["quality"]> {
+    return value === "crude" || value === "standard" || value === "fine" || value === "masterwork";
+  }
+
+  private isItemAffixArray(value: unknown): value is NonNullable<Item["affixes"]> {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+
+    return value.every((entry) => this.isItemAffix(entry));
+  }
+
+  private isItemAffix(value: unknown): value is NonNullable<Item["affixes"]>[number] {
+    if (!this.isRecord(value)) {
+      return false;
+    }
+
+    const record = value as UnknownRecord;
+    const id = record.id;
+    const label = record.label;
+    const stat = record.stat;
+    const affixValue = record.value;
+
+    const statValid = stat === "strength" || stat === "intellect" || stat === "vitality";
+
+    return (
+      this.isNonEmptyString(id) &&
+      this.isNonEmptyString(label) &&
+      statValid &&
+      this.isNumber(affixValue)
+    );
   }
 
   private isEventCategory(value: unknown): value is EventCard["category"] {

--- a/src/systems/EventBus.ts
+++ b/src/systems/EventBus.ts
@@ -2,7 +2,7 @@ import Phaser from "phaser";
 
 import type { BuildingSnapshot } from "../types/buildings";
 import type { EconomyForecast } from "../types/economy";
-import type { KnightsSnapshot } from "../types/state";
+import type { InventoryState, KnightsSnapshot } from "../types/state";
 import type { ResourceSnapshot } from "./ResourceManager";
 
 export const GameEvent = {
@@ -10,6 +10,7 @@ export const GameEvent = {
   ResourcesUpdated: "resource:updated",
   TimeScaleChanged: "time:scaleChanged",
   KnightStateUpdated: "knight:stateUpdated",
+  InventoryUpdated: "inventory:updated",
   WeekAdvanced: "time:weekAdvanced",
   EconomyForecastUpdated: "economy:forecastUpdated",
   BuildingsUpdated: "building:updated"
@@ -32,6 +33,7 @@ type GameEventMap = {
   [GameEvent.ResourcesUpdated]: ResourceSnapshot;
   [GameEvent.TimeScaleChanged]: number;
   [GameEvent.KnightStateUpdated]: KnightsSnapshot;
+  [GameEvent.InventoryUpdated]: InventoryState;
   [GameEvent.WeekAdvanced]: WeekTickPayload;
   [GameEvent.EconomyForecastUpdated]: EconomyForecast;
   [GameEvent.BuildingsUpdated]: BuildingSnapshot;

--- a/src/systems/InventorySystem.ts
+++ b/src/systems/InventorySystem.ts
@@ -1,0 +1,313 @@
+import type { InventoryItem, InventoryState } from "../types/state";
+import EventBus, { GameEvent } from "./EventBus";
+
+const DEFAULT_STATE: InventoryState = {
+  nextInstanceId: 1,
+  items: []
+};
+
+type MaterialRequirement = {
+  readonly itemId: string;
+  readonly quantity: number;
+};
+
+/**
+ * Centralised manager responsible for tracking crafting materials and equipment.
+ */
+class InventorySystem {
+  private state: InventoryState;
+  private initialized: boolean;
+
+  public constructor() {
+    this.state = { ...DEFAULT_STATE, items: [] };
+    this.initialized = false;
+  }
+
+  /**
+   * Hydrates inventory contents from persistence.
+   */
+  public initialize(state?: InventoryState): void {
+    if (this.initialized) {
+      return;
+    }
+
+    if (state) {
+      this.state = this.cloneState(this.sanitiseState(state));
+    } else {
+      this.state = this.cloneState(DEFAULT_STATE);
+    }
+
+    this.initialized = true;
+    this.emitSnapshot();
+  }
+
+  /**
+   * Clears runtime state when no longer required.
+   */
+  public shutdown(): void {
+    this.initialized = false;
+  }
+
+  /**
+   * Returns a deep clone of the current inventory state.
+   */
+  public getState(): InventoryState {
+    return this.cloneState(this.state);
+  }
+
+  /**
+   * Retrieves a clone of the active inventory for UI consumption.
+   */
+  public getSnapshot(): InventoryState {
+    return this.cloneState(this.state);
+  }
+
+  /**
+   * Returns a clone of all stored items.
+   */
+  public listItems(): InventoryItem[] {
+    return this.state.items.map((item) => this.cloneItem(item));
+  }
+
+  /**
+   * Looks up an item instance by identifier.
+   */
+  public getItemByInstanceId(instanceId: string): InventoryItem | undefined {
+    const match = this.state.items.find((item) => item.instanceId === instanceId);
+    return match ? this.cloneItem(match) : undefined;
+  }
+
+  /**
+   * Returns all items matching the specified type.
+   */
+  public getItemsByType(type: "equipment" | "material"): InventoryItem[] {
+    return this.state.items
+      .filter((item) => item.itemType === type)
+      .map((item) => this.cloneItem(item));
+  }
+
+  /**
+   * Adds a new entry to the inventory, stacking if applicable.
+   */
+  public addItem(item: InventoryItem): InventoryItem {
+    const { item: prepared, numericId } = this.prepareItem(item);
+
+    if (!this.initialized) {
+      this.state = this.cloneState(DEFAULT_STATE);
+      this.initialized = true;
+    }
+
+    let updatedItems: InventoryItem[] = [...this.state.items];
+    let addedItem = prepared;
+
+    if (prepared.itemType === "material" && !prepared.affixes && !prepared.quality) {
+      const existingIndex = updatedItems.findIndex(
+        (entry) =>
+          entry.itemType === "material" &&
+          entry.baseItemId === prepared.baseItemId &&
+          !entry.affixes &&
+          !entry.quality
+      );
+
+      if (existingIndex !== -1) {
+        const existing = updatedItems[existingIndex]!;
+        const merged: InventoryItem = {
+          ...existing,
+          quantity: existing.quantity + prepared.quantity
+        };
+        updatedItems = [...updatedItems];
+        updatedItems[existingIndex] = merged;
+        addedItem = merged;
+      } else {
+        updatedItems = [...updatedItems, prepared];
+      }
+    } else {
+      updatedItems = [...updatedItems, prepared];
+    }
+
+    this.state = {
+      nextInstanceId: Math.max(this.state.nextInstanceId, numericId + 1),
+      items: updatedItems
+    };
+
+    this.emitSnapshot();
+    return this.cloneItem(addedItem);
+  }
+
+  /**
+   * Consumes crafting materials if the inventory satisfies the requirements.
+   */
+  public consumeMaterials(requirements: ReadonlyArray<MaterialRequirement>): boolean {
+    if (!this.initialized) {
+      return false;
+    }
+
+    const aggregated = new Map<string, number>();
+    requirements.forEach((entry) => {
+      if (entry.quantity <= 0) {
+        return;
+      }
+      const current = aggregated.get(entry.itemId) ?? 0;
+      aggregated.set(entry.itemId, current + entry.quantity);
+    });
+
+    if (aggregated.size === 0) {
+      return true;
+    }
+
+    const inventoryTotals = new Map<string, number>();
+    this.state.items
+      .filter((item) => item.itemType === "material")
+      .forEach((item) => {
+        const current = inventoryTotals.get(item.baseItemId) ?? 0;
+        inventoryTotals.set(item.baseItemId, current + item.quantity);
+      });
+
+    const canFulfil = Array.from(aggregated.entries()).every(([itemId, quantity]) => {
+      const available = inventoryTotals.get(itemId) ?? 0;
+      return available >= quantity;
+    });
+
+    if (!canFulfil) {
+      return false;
+    }
+
+    const updatedItems: InventoryItem[] = [];
+    const remaining = new Map<string, number>(aggregated);
+
+    this.state.items.forEach((item) => {
+      if (item.itemType !== "material") {
+        updatedItems.push(item);
+        return;
+      }
+
+      const needed = remaining.get(item.baseItemId) ?? 0;
+      if (needed <= 0) {
+        updatedItems.push(item);
+        return;
+      }
+
+      const consumed = Math.min(needed, item.quantity);
+      const leftover = item.quantity - consumed;
+      if (leftover > 0) {
+        updatedItems.push({ ...item, quantity: leftover });
+      }
+      remaining.set(item.baseItemId, needed - consumed);
+    });
+
+    this.state = {
+      ...this.state,
+      items: updatedItems.filter((entry) => entry.quantity > 0 || entry.itemType !== "material")
+    };
+
+    this.emitSnapshot();
+    return true;
+  }
+
+  /**
+   * Marks an item as equipped to the specified knight.
+   */
+  public assignToKnight(instanceId: string, knightId?: string): void {
+    const index = this.state.items.findIndex((item) => item.instanceId === instanceId);
+    if (index === -1) {
+      return;
+    }
+
+    const updated = { ...this.state.items[index]! };
+    updated.equippedBy = knightId;
+
+    const nextItems = [...this.state.items];
+    nextItems[index] = updated;
+    this.state = { ...this.state, items: nextItems };
+    this.emitSnapshot();
+  }
+
+  /**
+   * Removes equipped flags for all items bound to the knight.
+   */
+  public clearAssignmentsForKnight(knightId: string): void {
+    let mutated = false;
+    const nextItems = this.state.items.map((item) => {
+      if (item.equippedBy === knightId) {
+        mutated = true;
+        return { ...item, equippedBy: undefined };
+      }
+      return item;
+    });
+
+    if (!mutated) {
+      return;
+    }
+
+    this.state = { ...this.state, items: nextItems };
+    this.emitSnapshot();
+  }
+
+  private prepareItem(item: InventoryItem): { readonly item: InventoryItem; readonly numericId: number } {
+    const cloned = this.cloneItem(item);
+    const identifier = this.generateInstanceId(cloned.instanceId);
+    const baseItemId = cloned.baseItemId && cloned.baseItemId.length > 0 ? cloned.baseItemId : cloned.id;
+    const quantity = Math.max(1, Math.floor(cloned.quantity));
+
+    const prepared: InventoryItem = {
+      ...cloned,
+      instanceId: identifier.id,
+      id: identifier.id,
+      baseItemId,
+      quantity
+    };
+
+    return { item: prepared, numericId: identifier.numericId };
+  }
+
+  private generateInstanceId(provided?: string): { readonly id: string; readonly numericId: number } {
+    const numeric = this.state.nextInstanceId;
+    if (provided && provided.trim().length > 0) {
+      return { id: provided, numericId: numeric };
+    }
+
+    const instanceId = `item-${numeric.toString().padStart(5, "0")}`;
+    return { id: instanceId, numericId: numeric };
+  }
+
+  private sanitiseState(state: InventoryState): InventoryState {
+    const nextInstanceId = Number.isFinite(state.nextInstanceId) && state.nextInstanceId > 0
+      ? Math.floor(state.nextInstanceId)
+      : DEFAULT_STATE.nextInstanceId;
+
+    const items = Array.isArray(state.items)
+      ? state.items
+          .map((item) => this.cloneItem(item))
+          .filter((item) => typeof item.instanceId === "string" && item.instanceId.length > 0)
+      : [];
+
+    return {
+      nextInstanceId,
+      items
+    };
+  }
+
+  private cloneState(state: InventoryState): InventoryState {
+    return {
+      nextInstanceId: state.nextInstanceId,
+      items: state.items.map((item) => this.cloneItem(item))
+    };
+  }
+
+  private cloneItem(item: InventoryItem): InventoryItem {
+    return {
+      ...item,
+      tags: [...item.tags],
+      effects: item.effects.map((effect) => ({ ...effect })),
+      affixes: item.affixes ? item.affixes.map((affix) => ({ ...affix })) : undefined
+    };
+  }
+
+  private emitSnapshot(): void {
+    EventBus.emit(GameEvent.InventoryUpdated, this.getSnapshot());
+  }
+}
+
+const inventorySystem = new InventorySystem();
+
+export default inventorySystem;

--- a/src/systems/KnightManager.ts
+++ b/src/systems/KnightManager.ts
@@ -1,6 +1,7 @@
-﻿import { KNIGHT_EPITHETS, KNIGHT_FIRST_NAMES, KNIGHT_PROFESSIONS, KNIGHT_TRAITS } from "../data/KnightDefinitions";
+import { KNIGHT_EPITHETS, KNIGHT_FIRST_NAMES, KNIGHT_PROFESSIONS, KNIGHT_TRAITS } from "../data/KnightDefinitions";
 import type {
   KnightAttributes,
+  KnightEquipmentSlots,
   KnightProfession,
   KnightRecord,
   KnightTraitId,
@@ -9,6 +10,8 @@ import type {
 } from "../types/state";
 import EventBus, { GameEvent } from "./EventBus";
 import RNG from "../utils/RNG";
+import inventorySystem from "./InventorySystem";
+import type { InventoryItem } from "../types/state";
 
 type KnightProfessionEntry = (typeof KNIGHT_PROFESSIONS)[number];
 
@@ -20,6 +23,14 @@ const MIN_ATTRIBUTE = 30;
 const MAX_ATTRIBUTE = 95;
 const MAX_FATIGUE = 100;
 const MAX_INJURY = 100;
+const MAX_TRINKETS = 3;
+
+const QUALITY_SCORE: Record<string, number> = {
+  crude: 2,
+  standard: 5,
+  fine: 9,
+  masterwork: 14
+};
 
 const createDefaultState = (): KnightsState => ({
   roster: [],
@@ -27,6 +38,8 @@ const createDefaultState = (): KnightsState => ({
   nextId: 1,
   candidateSeed: Date.now()
 });
+
+type EquipmentSlot = "weapon" | "armor" | "trinket";
 
 /**
  * Central coordinator for knight roster and recruitment pipelines.
@@ -47,7 +60,12 @@ class KnightManager {
    */
   public initialize(state?: KnightsState): void {
     if (state) {
-      this.state = state;
+      this.state = {
+        roster: state.roster.map((entry) => this.ensureEquipment(entry)),
+        candidates: state.candidates.map((entry) => this.ensureEquipment(entry)),
+        nextId: state.nextId,
+        candidateSeed: state.candidateSeed
+      };
     } else {
       this.state = createDefaultState();
     }
@@ -100,6 +118,14 @@ class KnightManager {
    */
   public getRoster(): KnightRecord[] {
     return this.state.roster.map((knight) => this.cloneKnight(knight));
+  }
+
+  /**
+   * Retrieves a specific roster member by identifier.
+   */
+  public getKnightById(id: string): KnightRecord | undefined {
+    const match = this.state.roster.find((knight) => knight.id === id);
+    return match ? this.cloneKnight(match) : undefined;
   }
 
   /**
@@ -164,6 +190,7 @@ class KnightManager {
       this.emitSnapshot();
     }
   }
+
   /**
    * Retrieves the current candidate listing.
    */
@@ -193,7 +220,8 @@ class KnightManager {
     const recruited: KnightRecord = {
       ...candidate,
       fatigue: Math.max(0, Math.min(MAX_FATIGUE, Math.round(candidate.fatigue * 0.5))),
-      injury: Math.max(0, Math.min(MAX_INJURY, Math.round(candidate.injury * 0.5)))
+      injury: Math.max(0, Math.min(MAX_INJURY, Math.round(candidate.injury * 0.5))),
+      equipment: this.ensureEquipment(candidate).equipment
     };
 
     this.state.roster.push(recruited);
@@ -215,6 +243,7 @@ class KnightManager {
       return false;
     }
 
+    inventorySystem.clearAssignmentsForKnight(knightId);
     this.state.roster.splice(index, 1);
     this.emitSnapshot();
     return true;
@@ -231,6 +260,159 @@ class KnightManager {
     this.state.candidates.length = 0;
     this.ensureCandidateCapacity();
     this.emitSnapshot();
+  }
+
+  /**
+   * Computes an aggregate power score for the supplied knight.
+   */
+  public getPowerScore(knight: KnightRecord): number {
+    const base = knight.attributes;
+    let might = base.might;
+    let agility = base.agility;
+    let willpower = base.willpower;
+    let vitality = 0;
+    let equipmentQualityBonus = 0;
+
+    const equippedItems = this.resolveEquippedItems(knight.equipment);
+    equippedItems.forEach((item) => {
+      equipmentQualityBonus += QUALITY_SCORE[item.quality ?? ""] ?? 0;
+
+      (item.affixes ?? []).forEach((affix) => {
+        switch (affix.stat) {
+          case "strength":
+            might += affix.value;
+            break;
+          case "intellect":
+            willpower += affix.value;
+            break;
+          case "vitality":
+            vitality += affix.value;
+            break;
+          default:
+            break;
+        }
+      });
+    });
+
+    const attributeScore = might * 1.25 + agility * 1.1 + willpower * 1.2;
+    const vitalityScore = vitality * 1.5;
+    const score = attributeScore + vitalityScore + equipmentQualityBonus;
+    return Math.round(score);
+  }
+
+  /**
+   * Equips an item instance to the specified knight slot.
+   */
+  public equipItem(knightId: string, slot: EquipmentSlot, instanceId: string): boolean {
+    const knightIndex = this.state.roster.findIndex((entry) => entry.id === knightId);
+    if (knightIndex === -1) {
+      return false;
+    }
+
+    const item = inventorySystem.getItemByInstanceId(instanceId);
+    if (!item || item.itemType !== "equipment") {
+      return false;
+    }
+
+    if (item.equippedBy && item.equippedBy !== knightId) {
+      return false;
+    }
+
+    const rosterCopy = [...this.state.roster];
+    const knight = rosterCopy[knightIndex]!;
+    const equipment = this.normaliseEquipment(knight.equipment);
+    let changed = false;
+
+    if (slot === "weapon") {
+      if (equipment.weaponId === instanceId) {
+        return true;
+      }
+
+      if (equipment.weaponId) {
+        inventorySystem.assignToKnight(equipment.weaponId, undefined);
+      }
+
+      equipment.weaponId = instanceId;
+      changed = true;
+    } else if (slot === "armor") {
+      if (equipment.armorId === instanceId) {
+        return true;
+      }
+
+      if (equipment.armorId) {
+        inventorySystem.assignToKnight(equipment.armorId, undefined);
+      }
+
+      equipment.armorId = instanceId;
+      changed = true;
+    } else if (slot === "trinket") {
+      if (equipment.trinketIds.includes(instanceId)) {
+        return true;
+      }
+
+      if (equipment.trinketIds.length >= MAX_TRINKETS) {
+        return false;
+      }
+
+      equipment.trinketIds = [...equipment.trinketIds, instanceId];
+      changed = true;
+    }
+
+    if (!changed) {
+      return false;
+    }
+
+    inventorySystem.assignToKnight(instanceId, knightId);
+    rosterCopy[knightIndex] = { ...knight, equipment };
+    this.state = { ...this.state, roster: rosterCopy };
+    this.emitSnapshot();
+    return true;
+  }
+
+  /**
+   * Removes an equipped item from the specified slot.
+   */
+  public unequipItem(knightId: string, slot: EquipmentSlot, instanceId?: string): boolean {
+    const knightIndex = this.state.roster.findIndex((entry) => entry.id === knightId);
+    if (knightIndex === -1) {
+      return false;
+    }
+
+    const rosterCopy = [...this.state.roster];
+    const knight = rosterCopy[knightIndex]!;
+    const equipment = this.normaliseEquipment(knight.equipment);
+    let removedId: string | undefined;
+
+    if (slot === "weapon") {
+      if (!equipment.weaponId || (instanceId && equipment.weaponId !== instanceId)) {
+        return false;
+      }
+      removedId = equipment.weaponId;
+      equipment.weaponId = undefined;
+    } else if (slot === "armor") {
+      if (!equipment.armorId || (instanceId && equipment.armorId !== instanceId)) {
+        return false;
+      }
+      removedId = equipment.armorId;
+      equipment.armorId = undefined;
+    } else if (slot === "trinket") {
+      const index = equipment.trinketIds.findIndex((id) => (instanceId ? id === instanceId : true));
+      if (index === -1) {
+        return false;
+      }
+      removedId = equipment.trinketIds[index];
+      equipment.trinketIds = equipment.trinketIds.filter((id, idx) => idx !== index);
+    }
+
+    if (!removedId) {
+      return false;
+    }
+
+    inventorySystem.assignToKnight(removedId, undefined);
+    rosterCopy[knightIndex] = { ...knight, equipment };
+    this.state = { ...this.state, roster: rosterCopy };
+    this.emitSnapshot();
+    return true;
   }
 
   private ensureCandidateCapacity(): void {
@@ -260,7 +442,12 @@ class KnightManager {
       attributes,
       trait,
       fatigue,
-      injury
+      injury,
+      equipment: {
+        weaponId: undefined,
+        armorId: undefined,
+        trinketIds: []
+      }
     };
   }
 
@@ -314,8 +501,61 @@ class KnightManager {
   private cloneKnight(knight: KnightRecord): KnightRecord {
     return {
       ...knight,
-      attributes: { ...knight.attributes }
+      attributes: { ...knight.attributes },
+      equipment: {
+        weaponId: knight.equipment.weaponId,
+        armorId: knight.equipment.armorId,
+        trinketIds: [...knight.equipment.trinketIds]
+      }
     };
+  }
+
+  private ensureEquipment(knight: KnightRecord): KnightRecord {
+    const equipment = this.normaliseEquipment(knight.equipment);
+    return { ...knight, equipment };
+  }
+
+  private normaliseEquipment(equipment?: KnightEquipmentSlots): KnightEquipmentSlots {
+    if (!equipment) {
+      return { weaponId: undefined, armorId: undefined, trinketIds: [] };
+    }
+
+    const trinketIds = Array.isArray(equipment.trinketIds)
+      ? equipment.trinketIds.filter((id): id is string => typeof id === "string").slice(0, MAX_TRINKETS)
+      : [];
+
+    return {
+      weaponId: typeof equipment.weaponId === "string" ? equipment.weaponId : undefined,
+      armorId: typeof equipment.armorId === "string" ? equipment.armorId : undefined,
+      trinketIds
+    };
+  }
+
+  private resolveEquippedItems(equipment: KnightEquipmentSlots): InventoryItem[] {
+    const items: InventoryItem[] = [];
+
+    if (equipment.weaponId) {
+      const weapon = inventorySystem.getItemByInstanceId(equipment.weaponId);
+      if (weapon) {
+        items.push(weapon);
+      }
+    }
+
+    if (equipment.armorId) {
+      const armor = inventorySystem.getItemByInstanceId(equipment.armorId);
+      if (armor) {
+        items.push(armor);
+      }
+    }
+
+    equipment.trinketIds.forEach((trinketId) => {
+      const trinket = inventorySystem.getItemByInstanceId(trinketId);
+      if (trinket) {
+        items.push(trinket);
+      }
+    });
+
+    return items;
   }
 
   private emitSnapshot(): void {
@@ -326,7 +566,3 @@ class KnightManager {
 const knightManager = new KnightManager();
 
 export default knightManager;
-
-
-
-

--- a/src/types/game.d.ts
+++ b/src/types/game.d.ts
@@ -6,6 +6,25 @@
 export type ItemRarity = "common" | "uncommon" | "rare" | "legendary";
 
 /**
+ * Quality tiers applied to crafted equipment, influencing affix rolls.
+ */
+export type ItemQuality = "crude" | "standard" | "fine" | "masterwork";
+
+/**
+ * Identifies a single attribute modifier applied by an item affix.
+ */
+export interface ItemAffix {
+  /** Machine-readable identifier of the affix. */
+  id: string;
+  /** Localised label presented to players. */
+  label: string;
+  /** Attribute key modified by the affix. */
+  stat: "strength" | "intellect" | "vitality";
+  /** Magnitude of the modifier. */
+  value: number;
+}
+
+/**
  * Represents a resource adjustment applied by data-driven effects.
  */
 export interface ResourceDelta {
@@ -26,6 +45,20 @@ export interface Item {
   value: number;
   tags: string[];
   effects: ResourceDelta[];
+  /** Optional quality classification for crafted equipment. */
+  quality?: ItemQuality;
+  /** Generated affix modifiers applied to the item. */
+  affixes?: ItemAffix[];
+  /** Unique runtime identifier for inventory tracking. */
+  instanceId?: string;
+  /** Reference to the originating base item definition. */
+  baseItemId?: string;
+  /** Quantity of identical items held in the stack. */
+  quantity?: number;
+  /** Indicates whether the item is suited for equipping or material use. */
+  itemType?: "equipment" | "material";
+  /** Identifier of the knight currently wielding the item, if any. */
+  equippedBy?: string;
 }
 
 /**

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,5 +1,18 @@
 import type { ResourceSnapshot } from "../systems/ResourceManager";
 import type { BuildingState } from "./buildings";
+import type { Item } from "./game";
+
+/**
+ * Identifies the equipment slots available to a knight.
+ */
+export interface KnightEquipmentSlots {
+  /** Instance identifier assigned to the equipped weapon. */
+  weaponId?: string;
+  /** Instance identifier assigned to the equipped armour. */
+  armorId?: string;
+  /** Instance identifiers for trinkets currently worn. */
+  trinketIds: string[];
+}
 
 /**
  * Identifiers describing the combat role a knight specializes in.
@@ -43,6 +56,32 @@ export interface KnightRecord {
   fatigue: number;
   /** Current injury severity, ranges from 0 (healthy) to 100 (incapacitated). */
   injury: number;
+  /** Equipped gear references for runtime stat calculation. */
+  equipment: KnightEquipmentSlots;
+}
+
+/**
+ * Representation of an inventory item persisted between sessions.
+ */
+export interface InventoryItem extends Item {
+  /** Runtime identifier allocated when the item enters the inventory. */
+  instanceId: string;
+  /** Quantity stored when the entry represents a stack. */
+  quantity: number;
+  /** Tag describing how the item is used in gameplay. */
+  itemType: NonNullable<Item["itemType"]>;
+  /** Identifier of the source item definition. */
+  baseItemId: string;
+}
+
+/**
+ * Persisted inventory contents for the player's vault.
+ */
+export interface InventoryState {
+  /** Sequential identifier allocated to the next item added to the inventory. */
+  nextInstanceId: number;
+  /** Stored inventory entries including materials and equipment. */
+  items: InventoryItem[];
 }
 
 /**
@@ -95,6 +134,8 @@ export interface GameState {
   resources: ResourceSnapshot;
   /** Pending tasks or constructions awaiting completion. */
   queue: QueueItemState[];
+  /** Item inventory including forged equipment and crafting materials. */
+  inventory: InventoryState;
   /** Knights roster, candidate listings, and generator metadata. */
   knights: KnightsState;
   /** Player progression for castle infrastructure. */


### PR DESCRIPTION
## Summary
- add a data-driven crafting system that rolls quality, rarity, and affixes for forged equipment
- introduce an inventory manager with persistence updates and integrate equipment handling into the knight manager
- surface a forge management panel in the UI with new toggles and equip flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b639867c832e87dc59e288036989