### PR TITLE
Add roguelike run and mandate selection flow

### DIFF
--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -4,8 +4,11 @@ import { SceneKeys } from "../data/SceneKeys";
 import { TextureKeys } from "../data/TextureKeys";
 import { createDefaultGameState } from "../data/GameStateFactory";
 import EventBus, { GameEvent } from "../systems/EventBus";
+import mandateSystem from "../systems/MandateSystem";
+import runSystem from "../systems/RunSystem";
 import RNG from "../utils/RNG";
 import SaveSystem, { SlotSummary } from "../utils/SaveSystem";
+import type { MandateCardView, RunSummary } from "../types/run";
 
 const SPARKLE_SETTINGS = {
   count: 48,
@@ -40,6 +43,29 @@ const ACTION_BUTTON_WIDTH = 96;
 const ACTION_BUTTON_HEIGHT = 34;
 const ACTION_BUTTON_GAP = 12;
 
+const OVERLAY_BACKDROP_COLOR = 0x04060d;
+const OVERLAY_BACKDROP_ALPHA = 0.78;
+const SUCCESSION_PANEL_WIDTH = 720;
+const SUCCESSION_PANEL_HEIGHT = 420;
+const SUCCESSION_PANEL_COLOR = 0x11203a;
+const MANDATE_CARD_WIDTH = 200;
+const MANDATE_CARD_HEIGHT = 230;
+const MANDATE_CARD_COLOR = 0x1a2d4a;
+const MANDATE_CARD_HOVER = 0x223c61;
+const MANDATE_CARD_HIGHLIGHT_COLOR = 0xf1c40f;
+const MANDATE_CARD_HIGHLIGHT_ALPHA = 0.55;
+const DETAIL_TEXT_COLOR = "#f0f5ff";
+const DETAIL_SUBTEXT_COLOR = "#d1dbff";
+const OVERLAY_BUTTON_WIDTH = 160;
+const OVERLAY_BUTTON_HEIGHT = 44;
+const OVERLAY_BUTTON_COLOR = 0x5c7aea;
+const OVERLAY_BUTTON_HOVER = 0x759bff;
+const DISABLED_BUTTON_COLOR = 0x3a4660;
+const LEGACY_PANEL_WIDTH = 640;
+const LEGACY_PANEL_HEIGHT = 360;
+const LEGACY_PANEL_COLOR = 0x0f1d33;
+const LEGACY_HIGHLIGHT_COLOR = "#f9f871";
+
 /**
  * Main menu where players can start or manage game sessions.
  */
@@ -49,6 +75,8 @@ export default class MainMenuScene extends Phaser.Scene {
   private readonly rng: RNG;
   private slotListContainer!: Phaser.GameObjects.Container;
   private emptySlotsLabel!: Phaser.GameObjects.Text;
+  private successionOverlay?: Phaser.GameObjects.Container;
+  private settlementOverlay?: Phaser.GameObjects.Container;
 
   public constructor() {
     super(MainMenuScene.KEY);
@@ -62,9 +90,16 @@ export default class MainMenuScene extends Phaser.Scene {
     const { width, height } = this.scale;
     this.cameras.main.setBackgroundColor(0x1b1b2f);
 
+    mandateSystem.initialize();
+
     this.spawnSparkles(width, height);
     this.createMenu(width, height);
     this.refreshSlotList();
+
+    const pendingSummary = runSystem.consumeLastSummary();
+    if (pendingSummary) {
+      this.presentSettlementSummary(pendingSummary);
+    }
   }
 
   /**
@@ -151,7 +186,7 @@ export default class MainMenuScene extends Phaser.Scene {
     });
 
     playButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => {
-      this.handleNewGame();
+      this.presentSuccessionFlow();
     });
   }
 
@@ -331,18 +366,6 @@ export default class MainMenuScene extends Phaser.Scene {
   }
 
   /**
-   * Generates a brand-new save slot with default state and enters the castle scene.
-   */
-  private handleNewGame(): void {
-    const slotId = this.generateSlotId();
-    const baseState = createDefaultGameState();
-    const persistedState = SaveSystem.save(slotId, baseState);
-
-    EventBus.emit(GameEvent.Start);
-    this.scene.start(SceneKeys.Castle, { state: persistedState, slotId });
-  }
-
-  /**
    * Loads an existing slot and transitions into gameplay when successful.
    */
   private handleLoad(slotId: string): void {
@@ -383,6 +406,526 @@ export default class MainMenuScene extends Phaser.Scene {
       .toString(36)
       .padStart(3, "0");
     return `slot-${timeComponent}-${randomComponent}`;
+  }
+
+  /**
+   * Opens the succession overlay allowing the player to draft a royal mandate.
+   */
+  private presentSuccessionFlow(): void {
+    this.clearSuccessionOverlay();
+    this.clearSettlementOverlay();
+    mandateSystem.initialize();
+
+    const { width, height } = this.scale;
+    const overlay = this.add.container(0, 0);
+    overlay.setDepth(20);
+    this.successionOverlay = overlay;
+
+    const backdrop = this.add.rectangle(
+      width / 2,
+      height / 2,
+      width,
+      height,
+      OVERLAY_BACKDROP_COLOR,
+      OVERLAY_BACKDROP_ALPHA
+    );
+    backdrop.setOrigin(0.5);
+    backdrop.setInteractive();
+    overlay.add(backdrop);
+
+    const panel = this.add.container(width / 2, height / 2);
+    overlay.add(panel);
+
+    const background = this.add.rectangle(
+      0,
+      0,
+      SUCCESSION_PANEL_WIDTH,
+      SUCCESSION_PANEL_HEIGHT,
+      SUCCESSION_PANEL_COLOR,
+      0.96
+    );
+    background.setOrigin(0.5);
+    background.setStrokeStyle(2, PANEL_BORDER_COLOR, 0.42);
+    panel.add(background);
+
+    const title = this.add.text(0, -SUCCESSION_PANEL_HEIGHT / 2 + 24, "New Sovereign Ascends", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "28px",
+      fontStyle: "bold",
+      color: PANEL_TITLE_COLOR
+    });
+    title.setOrigin(0.5, 0);
+    panel.add(title);
+
+    const subtitle = this.add.text(0, title.y + 34, "Draw a royal mandate to define this reign.", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      color: PANEL_SUBTITLE_COLOR
+    });
+    subtitle.setOrigin(0.5, 0);
+    panel.add(subtitle);
+
+    const runSeed = Math.floor(this.rng.next() * 1_000_000_000) + 29;
+    const cardSeed = Math.floor(this.rng.next() * 1_000_000_000) + 47;
+    const cards = mandateSystem.drawMandateOptions(cardSeed);
+
+    const seedLabel = this.add.text(
+      SUCCESSION_PANEL_WIDTH / 2 - 24,
+      -SUCCESSION_PANEL_HEIGHT / 2 + 30,
+      `Seed ${runSeed.toString(36).toUpperCase()}`,
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: PANEL_SUBTITLE_COLOR
+      }
+    );
+    seedLabel.setOrigin(1, 0);
+    panel.add(seedLabel);
+
+    const detailText = this.add.text(
+      -SUCCESSION_PANEL_WIDTH / 2 + 32,
+      -SUCCESSION_PANEL_HEIGHT / 2 + 120,
+      "Select a royal mandate to review its decrees.",
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "16px",
+        color: DETAIL_TEXT_COLOR,
+        wordWrap: { width: SUCCESSION_PANEL_WIDTH - 64 }
+      }
+    );
+    detailText.setOrigin(0, 0);
+    panel.add(detailText);
+
+    const milestoneText = this.add.text(
+      -SUCCESSION_PANEL_WIDTH / 2 + 32,
+      detailText.y + 134,
+      "",
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "15px",
+        color: DETAIL_SUBTEXT_COLOR,
+        wordWrap: { width: SUCCESSION_PANEL_WIDTH - 64 }
+      }
+    );
+    milestoneText.setOrigin(0, 0);
+    panel.add(milestoneText);
+
+    const highlights: Phaser.GameObjects.Rectangle[] = [];
+    const spacing = MANDATE_CARD_WIDTH + 36;
+    const startX = cards.length > 0 ? -((cards.length - 1) * spacing) / 2 : 0;
+
+    let selectedCard: MandateCardView | null = null;
+    let setConfirmEnabled: (enabled: boolean) => void = () => {
+      /* noop until button created */
+    };
+
+    const handleSelect = (card: MandateCardView, highlight: Phaser.GameObjects.Rectangle): void => {
+      highlights.forEach((entry) => entry.setAlpha(0));
+      highlight.setAlpha(MANDATE_CARD_HIGHLIGHT_ALPHA);
+      selectedCard = card;
+      detailText.setText(this.formatMandateDetails(card));
+      milestoneText.setText(this.formatMilestones(card));
+      setConfirmEnabled(true);
+    };
+
+    cards.forEach((card, index) => {
+      const highlight = this.createMandateCard(panel, card, startX + index * spacing, handleSelect);
+      highlights.push(highlight);
+    });
+
+    const buttonY = SUCCESSION_PANEL_HEIGHT / 2 - 48;
+    this.createOverlayButton(panel, "Cancel", -120, buttonY, () => {
+      this.clearSuccessionOverlay();
+    });
+
+    const confirmControl = this.createOverlayButton(panel, "Begin Reign", 120, buttonY, () => {
+      this.finalizeSuccessionSelection(selectedCard, runSeed);
+    });
+    setConfirmEnabled = confirmControl.setEnabled;
+
+    if (cards.length === 0) {
+      detailText.setText("No royal mandates are available. Begin the reign unburdened.");
+      milestoneText.setText("");
+      setConfirmEnabled(true);
+    } else {
+      setConfirmEnabled(false);
+    }
+  }
+
+  /**
+   * Persists a new save slot and enters gameplay with the selected mandates.
+   */
+  private finalizeSuccessionSelection(selection: MandateCardView | null, runSeed: number): void {
+    const slotId = this.generateSlotId();
+    const baseState = createDefaultGameState();
+    const persistedState = SaveSystem.save(slotId, baseState);
+    const mandateIds = selection ? [selection.id] : [];
+
+    runSystem.startNewRun(runSeed, mandateIds);
+    this.clearSuccessionOverlay();
+
+    EventBus.emit(GameEvent.Start);
+    this.scene.start(SceneKeys.Castle, { state: persistedState, slotId });
+  }
+
+  /**
+   * Presents the legacy summary overlay after a run concludes.
+   */
+  private presentSettlementSummary(summary: RunSummary): void {
+    this.clearSettlementOverlay();
+
+    const { width, height } = this.scale;
+    const overlay = this.add.container(0, 0);
+    overlay.setDepth(18);
+    this.settlementOverlay = overlay;
+
+    const backdrop = this.add.rectangle(
+      width / 2,
+      height / 2,
+      width,
+      height,
+      OVERLAY_BACKDROP_COLOR,
+      OVERLAY_BACKDROP_ALPHA
+    );
+    backdrop.setOrigin(0.5);
+    backdrop.setInteractive();
+    overlay.add(backdrop);
+
+    const panel = this.add.container(width / 2, height / 2);
+    overlay.add(panel);
+
+    const background = this.add.rectangle(0, 0, LEGACY_PANEL_WIDTH, LEGACY_PANEL_HEIGHT, LEGACY_PANEL_COLOR, 0.95);
+    background.setOrigin(0.5);
+    background.setStrokeStyle(2, PANEL_BORDER_COLOR, 0.4);
+    panel.add(background);
+
+    const title = this.add.text(0, -LEGACY_PANEL_HEIGHT / 2 + 24, "Succession Ledger", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "26px",
+      fontStyle: "bold",
+      color: PANEL_TITLE_COLOR
+    });
+    title.setOrigin(0.5, 0);
+    panel.add(title);
+
+    const outcomeLabel = summary.outcome === "victory" ? "Triumphant Reign" : "Lessons of Defeat";
+    const outcomeText = this.add.text(0, title.y + 36, outcomeLabel, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      color: PANEL_SUBTITLE_COLOR
+    });
+    outcomeText.setOrigin(0.5, 0);
+    panel.add(outcomeText);
+
+    const legacyValue = this.add.text(0, outcomeText.y + 46, `${summary.legacyPoints} Legacy`, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "32px",
+      fontStyle: "bold",
+      color: LEGACY_HIGHLIGHT_COLOR
+    });
+    legacyValue.setOrigin(0.5, 0);
+    panel.add(legacyValue);
+
+    const notesText = this.add.text(
+      -LEGACY_PANEL_WIDTH / 2 + 32,
+      legacyValue.y + 44,
+      summary.notes.map((note) => `• ${note}`).join("\n\n"),
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "15px",
+        color: DETAIL_TEXT_COLOR,
+        wordWrap: { width: LEGACY_PANEL_WIDTH - 64 }
+      }
+    );
+    notesText.setOrigin(0, 0);
+    panel.add(notesText);
+
+    const nextTitleY = LEGACY_PANEL_HEIGHT / 2 - 140;
+    const nextTitle = this.add.text(
+      -LEGACY_PANEL_WIDTH / 2 + 32,
+      nextTitleY,
+      "Next Reign Mandates",
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "16px",
+        fontStyle: "bold",
+        color: PANEL_TITLE_COLOR
+      }
+    );
+    nextTitle.setOrigin(0, 0);
+    panel.add(nextTitle);
+
+    const modifierSummary =
+      summary.modifiers.length > 0
+        ? summary.modifiers
+            .map(
+              (modifier) =>
+                `• ${modifier.label} — ${modifier.durationDays}d, +${modifier.prestigeReward} prestige`
+            )
+            .join("\n")
+        : "• No mandates will carry into the next succession.";
+
+    const modifiersBlock = this.add.text(
+      -LEGACY_PANEL_WIDTH / 2 + 32,
+      nextTitle.y + 28,
+      modifierSummary,
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "15px",
+        color: DETAIL_TEXT_COLOR,
+        wordWrap: { width: LEGACY_PANEL_WIDTH - 64 }
+      }
+    );
+    modifiersBlock.setOrigin(0, 0);
+    panel.add(modifiersBlock);
+
+    const seedLabel = this.add.text(
+      LEGACY_PANEL_WIDTH / 2 - 24,
+      -LEGACY_PANEL_HEIGHT / 2 + 30,
+      `Seed ${summary.seed.toString(36).toUpperCase()}`,
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: PANEL_SUBTITLE_COLOR
+      }
+    );
+    seedLabel.setOrigin(1, 0);
+    panel.add(seedLabel);
+
+    const buttonY = LEGACY_PANEL_HEIGHT / 2 - 48;
+    this.createOverlayButton(panel, "Archive Legacy", 0, buttonY, () => {
+      this.clearSettlementOverlay();
+    });
+  }
+
+  private createMandateCard(
+    parent: Phaser.GameObjects.Container,
+    card: MandateCardView,
+    positionX: number,
+    onSelect: (card: MandateCardView, highlight: Phaser.GameObjects.Rectangle) => void
+  ): Phaser.GameObjects.Rectangle {
+    const container = this.add.container(positionX, -20);
+    parent.add(container);
+
+    const highlight = this.add.rectangle(
+      0,
+      0,
+      MANDATE_CARD_WIDTH + 16,
+      MANDATE_CARD_HEIGHT + 16,
+      MANDATE_CARD_HIGHLIGHT_COLOR,
+      0
+    );
+    highlight.setOrigin(0.5);
+
+    const background = this.add.rectangle(0, 0, MANDATE_CARD_WIDTH, MANDATE_CARD_HEIGHT, MANDATE_CARD_COLOR, 0.94);
+    background.setOrigin(0.5);
+    background.setStrokeStyle(2, PANEL_BORDER_COLOR, 0.38);
+    background.setInteractive({ useHandCursor: true });
+
+    const title = this.add.text(0, -MANDATE_CARD_HEIGHT / 2 + 14, card.title, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      fontStyle: "bold",
+      color: PANEL_TITLE_COLOR,
+      align: "center",
+      wordWrap: { width: MANDATE_CARD_WIDTH - 24 }
+    });
+    title.setOrigin(0.5, 0);
+
+    const summary = this.add.text(0, -MANDATE_CARD_HEIGHT / 2 + 62, card.summary, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "14px",
+      color: PANEL_SUBTITLE_COLOR,
+      align: "center",
+      wordWrap: { width: MANDATE_CARD_WIDTH - 24 }
+    });
+    summary.setOrigin(0.5, 0);
+
+    const footer = this.add.text(
+      0,
+      MANDATE_CARD_HEIGHT / 2 - 54,
+      `Prestige +${card.prestigeReward}\nDuration ${card.durationDays}d`,
+      {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "14px",
+        color: DETAIL_TEXT_COLOR,
+        align: "center"
+      }
+    );
+    footer.setOrigin(0.5, 0);
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OVER, () => {
+      background.setFillStyle(MANDATE_CARD_HOVER, 0.95);
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OUT, () => {
+      background.setFillStyle(MANDATE_CARD_COLOR, 0.94);
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+      background.setFillStyle(MANDATE_CARD_HOVER, 0.95);
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => {
+      background.setFillStyle(MANDATE_CARD_COLOR, 0.94);
+      onSelect(card, highlight);
+    });
+
+    container.add([highlight, background, title, summary, footer]);
+    return highlight;
+  }
+
+  private formatMandateDetails(card: MandateCardView): string {
+    const lines: string[] = [];
+    lines.push(card.effectSummary);
+    lines.push("");
+    lines.push("Requirements:");
+    if (card.requirements.length === 0) {
+      lines.push("• None specified.");
+    } else {
+      card.requirements.forEach((requirement) => {
+        lines.push(`• ${this.formatRequirement(requirement)}`);
+      });
+    }
+    lines.push("");
+    lines.push("Rewards:");
+    lines.push(this.formatConsequenceList(card.rewards));
+    lines.push("");
+    lines.push("Penalties:");
+    lines.push(this.formatConsequenceList(card.penalties));
+    return lines.join("\n");
+  }
+
+  private formatMilestones(card: MandateCardView): string {
+    if (card.milestones.length === 0) {
+      return "";
+    }
+
+    const lines = card.milestones.map(
+      (milestone) => `• Day ${milestone.day}: ${milestone.label} — ${milestone.description}`
+    );
+    return `Milestones:\n${lines.join("\n")}`;
+  }
+
+  private formatRequirement(requirement: MandateCardView["requirements"][number]): string {
+    const comparison = requirement.comparison === "atLeast" ? "≥" : "≤";
+    return `${this.capitalizeResource(requirement.resource)} ${comparison} ${requirement.target}`;
+  }
+
+  private formatConsequenceList(entries: ReadonlyArray<{ resource: string; amount: number }>): string {
+    if (entries.length === 0) {
+      return "• None.";
+    }
+
+    return entries
+      .map((entry) => `• ${this.formatConsequence(entry)}`)
+      .join("\n");
+  }
+
+  private formatConsequence(entry: { resource: string; amount: number }): string {
+    const sign = entry.amount >= 0 ? "+" : "";
+    return `${sign}${entry.amount} ${this.capitalizeResource(entry.resource)}`;
+  }
+
+  private capitalizeResource(resource: string): string {
+    return resource.length === 0
+      ? resource
+      : resource.charAt(0).toUpperCase() + resource.slice(1);
+  }
+
+  private createOverlayButton(
+    parent: Phaser.GameObjects.Container,
+    label: string,
+    centerX: number,
+    centerY: number,
+    onActivate: () => void
+  ): { container: Phaser.GameObjects.Container; setEnabled: (enabled: boolean) => void } {
+    const container = this.add.container(centerX, centerY);
+    parent.add(container);
+
+    const background = this.add.rectangle(
+      0,
+      0,
+      OVERLAY_BUTTON_WIDTH,
+      OVERLAY_BUTTON_HEIGHT,
+      OVERLAY_BUTTON_COLOR,
+      1
+    );
+    background.setOrigin(0.5);
+    background.setStrokeStyle(1, PANEL_BORDER_COLOR, 0.4);
+
+    const text = this.add.text(0, 0, label, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      fontStyle: "bold",
+      color: BUTTON_TEXT_LIGHT
+    });
+    text.setOrigin(0.5);
+
+    container.add([background, text]);
+
+    let enabled = true;
+
+    const applyNeutralFill = (): void => {
+      background.setFillStyle(enabled ? OVERLAY_BUTTON_COLOR : DISABLED_BUTTON_COLOR, 1);
+      text.setAlpha(enabled ? 1 : 0.65);
+    };
+
+    background.setInteractive({ useHandCursor: true });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OVER, () => {
+      if (!enabled) {
+        return;
+      }
+      background.setFillStyle(OVERLAY_BUTTON_HOVER, 1);
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_OUT, () => {
+      applyNeutralFill();
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+      if (!enabled) {
+        return;
+      }
+      background.setFillStyle(OVERLAY_BUTTON_HOVER, 1);
+    });
+
+    background.on(Phaser.Input.Events.GAMEOBJECT_POINTER_UP, () => {
+      if (!enabled) {
+        return;
+      }
+      applyNeutralFill();
+      onActivate();
+    });
+
+    const setEnabled = (state: boolean): void => {
+      enabled = state;
+      if (enabled) {
+        background.setInteractive({ useHandCursor: true });
+      } else {
+        background.disableInteractive();
+      }
+      applyNeutralFill();
+    };
+
+    applyNeutralFill();
+
+    return { container, setEnabled };
+  }
+
+  private clearSuccessionOverlay(): void {
+    if (this.successionOverlay) {
+      this.successionOverlay.destroy(true);
+      this.successionOverlay = undefined;
+    }
+  }
+
+  private clearSettlementOverlay(): void {
+    if (this.settlementOverlay) {
+      this.settlementOverlay.destroy(true);
+      this.settlementOverlay = undefined;
+    }
   }
 }
 

--- a/src/systems/MandateSystem.ts
+++ b/src/systems/MandateSystem.ts
@@ -1,0 +1,202 @@
+import dataRegistry from "./DataRegistry";
+import RNG from "../utils/RNG";
+import type { RoyalMandate, MandateRequirement, MandateConsequence } from "../types/game";
+import type { MandateCardView, MandateMilestone, RunModifier } from "../types/run";
+
+const DEFAULT_CARD_COUNT = 3;
+
+const cloneRequirement = (requirement: MandateRequirement): MandateRequirement => ({
+  resource: requirement.resource,
+  target: requirement.target,
+  comparison: requirement.comparison
+});
+
+const cloneConsequence = (consequence: MandateConsequence): MandateConsequence => ({
+  resource: consequence.resource,
+  amount: consequence.amount
+});
+
+const cloneMandate = (mandate: RoyalMandate): RoyalMandate => ({
+  ...mandate,
+  requirements: mandate.requirements.map(cloneRequirement),
+  rewards: mandate.rewards.map(cloneConsequence),
+  penalties: mandate.penalties.map(cloneConsequence)
+});
+
+const capitalise = (value: string): string =>
+  value.length === 0 ? value : value.charAt(0).toUpperCase() + value.slice(1);
+
+const describeRequirement = (requirement: MandateRequirement): string => {
+  const symbol = requirement.comparison === "atLeast" ? "≥" : "≤";
+  return `${capitalise(requirement.resource)} ${symbol} ${requirement.target}`;
+};
+
+const describeConsequences = (consequences: MandateConsequence[]): string => {
+  if (consequences.length === 0) {
+    return "none";
+  }
+  return consequences
+    .map((entry) => {
+      const sign = entry.amount >= 0 ? "+" : "";
+      return `${sign}${entry.amount} ${capitalise(entry.resource)}`;
+    })
+    .join(", ");
+};
+
+/**
+ * Coordinates royal mandate card presentation and milestone generation.
+ */
+class MandateSystem {
+  private initialized = false;
+  private mandates: RoyalMandate[] = [];
+
+  /**
+   * Loads mandate definitions from the shared data registry on first use.
+   */
+  public initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    dataRegistry.initialize();
+    this.mandates = dataRegistry.getRoyalMandates().map(cloneMandate);
+    this.initialized = true;
+  }
+
+  /**
+   * Draws a subset of mandate cards using the provided seed for reproducibility.
+   */
+  public drawMandateOptions(seed: number, count: number = DEFAULT_CARD_COUNT): MandateCardView[] {
+    this.ensureInitialized();
+    const rng = new RNG(seed);
+    const pool = [...this.mandates];
+    const options: MandateCardView[] = [];
+
+    const total = Math.min(count, pool.length);
+
+    for (let index = 0; index < total; index += 1) {
+      if (pool.length === 0) {
+        break;
+      }
+
+      const selectionIndex = Math.floor(rng.next() * pool.length);
+      const [mandate] = pool.splice(selectionIndex, 1);
+      if (!mandate) {
+        continue;
+      }
+
+      options.push(this.createCardView(mandate));
+    }
+
+    return options;
+  }
+
+  /**
+   * Retrieves a mandate card representation by identifier.
+   */
+  public getMandateCard(id: string): MandateCardView | undefined {
+    this.ensureInitialized();
+    const mandate = this.mandates.find((entry) => entry.id === id);
+    return mandate ? this.createCardView(mandate) : undefined;
+  }
+
+  /**
+   * Converts a mandate definition into a run modifier for the active session.
+   */
+  public createRunModifier(id: string): RunModifier | undefined {
+    this.ensureInitialized();
+    const mandate = this.mandates.find((entry) => entry.id === id);
+    if (!mandate) {
+      return undefined;
+    }
+
+    return {
+      id: `mandate:${mandate.id}`,
+      label: mandate.title,
+      description: this.describeMandate(mandate),
+      prestigeReward: mandate.prestigeReward,
+      durationDays: mandate.durationDays,
+      requirements: mandate.requirements.map(cloneRequirement),
+      rewards: mandate.rewards.map(cloneConsequence),
+      penalties: mandate.penalties.map(cloneConsequence),
+      milestones: this.generateMilestones(mandate)
+    } satisfies RunModifier;
+  }
+
+  /**
+   * Produces a human-readable summary for a mandate combining requirements and outcomes.
+   */
+  public describeMandate(mandate: RoyalMandate): string {
+    const requirementText =
+      mandate.requirements.length > 0
+        ? `Maintain ${mandate.requirements.map(describeRequirement).join(", ")}.`
+        : "No explicit upkeep requirements.";
+
+    const rewardText = `Rewards: ${describeConsequences(mandate.rewards)}.`;
+    const penaltyText = `Failure: ${describeConsequences(mandate.penalties)}.`;
+
+    return `${requirementText} ${rewardText} ${penaltyText}`.trim();
+  }
+
+  /**
+   * Generates pacing milestones that communicate expected progress beats.
+   */
+  public generateMilestones(mandate: RoyalMandate): MandateMilestone[] {
+    const duration = Math.max(1, Math.floor(mandate.durationDays));
+    const midPoint = Math.max(1, Math.floor(duration / 2));
+    const primaryRequirement = mandate.requirements[0];
+    const requirementFocus =
+      typeof primaryRequirement !== "undefined"
+        ? describeRequirement(primaryRequirement)
+        : "Maintain stability";
+
+    const milestones: MandateMilestone[] = [
+      {
+        order: 1,
+        day: 0,
+        label: "Edict Proclaimed",
+        description: `The royal court announces \"${mandate.title}\" to the realm.`
+      },
+      {
+        order: 2,
+        day: midPoint,
+        label: "Council Review",
+        description: `Progress is audited. Ensure ${requirementFocus}.`
+      },
+      {
+        order: 3,
+        day: duration,
+        label: "Final Audience",
+        description: `Present results to claim ${mandate.prestigeReward} prestige or face penalties.`
+      }
+    ];
+
+    return milestones;
+  }
+
+  private createCardView(mandate: RoyalMandate): MandateCardView {
+    return {
+      id: mandate.id,
+      title: mandate.title,
+      summary: mandate.summary,
+      prestigeReward: mandate.prestigeReward,
+      durationDays: mandate.durationDays,
+      requirements: mandate.requirements.map(cloneRequirement),
+      rewards: mandate.rewards.map(cloneConsequence),
+      penalties: mandate.penalties.map(cloneConsequence),
+      effectSummary: this.describeMandate(mandate),
+      milestones: this.generateMilestones(mandate).map((entry) => ({ ...entry })),
+      definition: cloneMandate(mandate)
+    } satisfies MandateCardView;
+  }
+
+  private ensureInitialized(): void {
+    if (!this.initialized) {
+      throw new Error("MandateSystem must be initialized before use.");
+    }
+  }
+}
+
+const mandateSystem = new MandateSystem();
+
+export default mandateSystem;

--- a/src/systems/RunSystem.ts
+++ b/src/systems/RunSystem.ts
@@ -1,0 +1,329 @@
+import mandateSystem from "./MandateSystem";
+import type { ActiveRunState, RunModifier, RunOutcome, RunSummary } from "../types/run";
+
+interface StorageAdapter {
+  readonly setItem: (key: string, value: string) => void;
+  readonly getItem: (key: string) => string | null;
+  readonly removeItem: (key: string) => void;
+}
+
+const STORAGE_KEY = "dragon-succession:run:last-summary";
+
+const memoryStorage = new Map<string, string>();
+
+const createStorageAdapter = (): StorageAdapter => {
+  if (typeof window !== "undefined" && typeof window.localStorage !== "undefined") {
+    return window.localStorage;
+  }
+
+  return {
+    setItem: (key: string, value: string) => {
+      memoryStorage.set(key, value);
+    },
+    getItem: (key: string) => memoryStorage.get(key) ?? null,
+    removeItem: (key: string) => {
+      memoryStorage.delete(key);
+    }
+  } satisfies StorageAdapter;
+};
+
+const cloneModifier = (modifier: RunModifier): RunModifier => ({
+  id: modifier.id,
+  label: modifier.label,
+  description: modifier.description,
+  prestigeReward: modifier.prestigeReward,
+  durationDays: modifier.durationDays,
+  requirements: modifier.requirements.map((entry) => ({
+    resource: entry.resource,
+    target: entry.target,
+    comparison: entry.comparison
+  })),
+  rewards: modifier.rewards.map((entry) => ({
+    resource: entry.resource,
+    amount: entry.amount
+  })),
+  penalties: modifier.penalties.map((entry) => ({
+    resource: entry.resource,
+    amount: entry.amount
+  })),
+  milestones: modifier.milestones.map((entry) => ({
+    order: entry.order,
+    day: entry.day,
+    label: entry.label,
+    description: entry.description
+  }))
+});
+
+const cloneSummary = (summary: RunSummary): RunSummary => ({
+  runId: summary.runId,
+  seed: summary.seed,
+  outcome: summary.outcome,
+  legacyPoints: summary.legacyPoints,
+  completedAt: summary.completedAt,
+  modifiers: summary.modifiers.map(cloneModifier),
+  notes: [...summary.notes]
+});
+
+const cloneActiveRun = (run: ActiveRunState): ActiveRunState => ({
+  runId: run.runId,
+  seed: run.seed,
+  startedAt: run.startedAt,
+  modifiers: run.modifiers.map(cloneModifier)
+});
+
+const calculateLegacyPoints = (outcome: RunOutcome, modifiers: ReadonlyArray<RunModifier>): number => {
+  const base = outcome === "victory" ? 120 : 45;
+  const prestigeTotal = modifiers.reduce((total, modifier) => total + modifier.prestigeReward, 0);
+  const diversityBonus = modifiers.length * 8;
+  const prestigeBonus = prestigeTotal * 12;
+  return Math.max(0, Math.round(base + prestigeBonus + diversityBonus));
+};
+
+const composeLegacyNotes = (outcome: RunOutcome, modifiers: ReadonlyArray<RunModifier>): string[] => {
+  const notes: string[] = [];
+  notes.push(
+    outcome === "victory"
+      ? "The realm celebrates a decisive triumph over the wyrm."
+      : "Though defeated, the lineage steels itself for another attempt."
+  );
+
+  modifiers.forEach((modifier) => {
+    notes.push(`${modifier.label}: ${modifier.description}`);
+  });
+
+  if (modifiers.length === 0) {
+    notes.push("No royal mandates were enforced during this reign.");
+  } else {
+    const prestigeTotal = modifiers.reduce((total, modifier) => total + modifier.prestigeReward, 0);
+    notes.push(`Heirs inherit ${prestigeTotal} accumulated prestige from honoured mandates.`);
+  }
+
+  return notes;
+};
+
+const generateRunId = (seed: number): string => `run-${seed.toString(36)}-${Date.now().toString(36)}`;
+
+/**
+ * Tracks the lifecycle of roguelike runs including modifiers and legacy scoring.
+ */
+class RunSystem {
+  private readonly storage: StorageAdapter;
+  private activeRun: ActiveRunState | null;
+  private pendingSummary: RunSummary | null;
+
+  public constructor() {
+    this.storage = createStorageAdapter();
+    this.activeRun = null;
+    this.pendingSummary = this.readStoredSummary();
+  }
+
+  /**
+   * Starts a fresh run with the provided seed and selected mandate identifiers.
+   */
+  public startNewRun(seed: number, selectedMandates: ReadonlyArray<string>): ActiveRunState {
+    mandateSystem.initialize();
+    const modifiers: RunModifier[] = selectedMandates
+      .map((mandateId) => mandateSystem.createRunModifier(mandateId))
+      .filter((modifier): modifier is RunModifier => typeof modifier !== "undefined")
+      .map(cloneModifier);
+
+    const runId = generateRunId(seed);
+    const startedAt = Date.now();
+    this.activeRun = { runId, seed, startedAt, modifiers } satisfies ActiveRunState;
+    this.persistSummary(null);
+    this.pendingSummary = null;
+    return cloneActiveRun(this.activeRun);
+  }
+
+  /**
+   * Finalises the active run, computing legacy points and persisting the summary.
+   */
+  public endRun(outcome: RunOutcome): RunSummary {
+    const active = this.activeRun;
+    const seed = active?.seed ?? Math.floor(Date.now() % 1_000_000_000) + 13;
+    const modifiers = active?.modifiers ?? [];
+    const runId = active?.runId ?? generateRunId(seed);
+
+    const summary: RunSummary = {
+      runId,
+      seed,
+      outcome,
+      legacyPoints: calculateLegacyPoints(outcome, modifiers),
+      completedAt: Date.now(),
+      modifiers: modifiers.map(cloneModifier),
+      notes: composeLegacyNotes(outcome, modifiers)
+    } satisfies RunSummary;
+
+    this.activeRun = null;
+    this.pendingSummary = summary;
+    this.persistSummary(summary);
+    return cloneSummary(summary);
+  }
+
+  /**
+   * Exposes the modifiers affecting the currently active run.
+   */
+  public getCurrentRunModifiers(): RunModifier[] {
+    return this.activeRun ? this.activeRun.modifiers.map(cloneModifier) : [];
+  }
+
+  /**
+   * Returns metadata about the active run if one is in progress.
+   */
+  public getActiveRun(): ActiveRunState | null {
+    return this.activeRun ? cloneActiveRun(this.activeRun) : null;
+  }
+
+  /**
+   * Returns the most recent stored run summary without clearing it.
+   */
+  public peekLastSummary(): RunSummary | null {
+    return this.pendingSummary ? cloneSummary(this.pendingSummary) : null;
+  }
+
+  /**
+   * Returns the stored run summary and clears it from persistent storage.
+   */
+  public consumeLastSummary(): RunSummary | null {
+    const summary = this.pendingSummary;
+    if (!summary) {
+      return null;
+    }
+
+    this.pendingSummary = null;
+    this.persistSummary(null);
+    return cloneSummary(summary);
+  }
+
+  private readStoredSummary(): RunSummary | null {
+    const raw = this.storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as RunSummary;
+      if (this.isValidSummary(parsed)) {
+        return cloneSummary(parsed);
+      }
+    } catch (error) {
+      console.warn("[RunSystem] Failed to parse stored run summary", error);
+    }
+
+    this.storage.removeItem(STORAGE_KEY);
+    return null;
+  }
+
+  private persistSummary(summary: RunSummary | null): void {
+    if (!summary) {
+      this.storage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    this.storage.setItem(STORAGE_KEY, JSON.stringify(summary));
+  }
+
+  private isValidSummary(value: unknown): value is RunSummary {
+    if (typeof value !== "object" || value === null) {
+      return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+    const runId = candidate.runId;
+    const seed = candidate.seed;
+    const outcome = candidate.outcome;
+    const legacyPoints = candidate.legacyPoints;
+    const completedAt = candidate.completedAt;
+    const modifiers = candidate.modifiers;
+    const notes = candidate.notes;
+
+    const outcomeValid = outcome === "victory" || outcome === "defeat";
+    const modifiersValid = Array.isArray(modifiers) && modifiers.every((entry) => this.isValidModifier(entry));
+    const notesValid = Array.isArray(notes) && notes.every((entry) => typeof entry === "string");
+
+    return (
+      typeof runId === "string" &&
+      typeof seed === "number" &&
+      Number.isFinite(seed) &&
+      outcomeValid &&
+      typeof legacyPoints === "number" &&
+      Number.isFinite(legacyPoints) &&
+      typeof completedAt === "number" &&
+      Number.isFinite(completedAt) &&
+      modifiersValid &&
+      notesValid
+    );
+  }
+
+  private isValidModifier(value: unknown): value is RunModifier {
+    if (typeof value !== "object" || value === null) {
+      return false;
+    }
+
+    const record = value as Record<string, unknown>;
+    const id = record.id;
+    const label = record.label;
+    const description = record.description;
+    const prestigeReward = record.prestigeReward;
+    const durationDays = record.durationDays;
+    const requirements = record.requirements;
+    const rewards = record.rewards;
+    const penalties = record.penalties;
+    const milestones = record.milestones;
+
+    const requirementValid =
+      Array.isArray(requirements) &&
+      requirements.every((entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as Record<string, unknown>).resource === "string" &&
+        typeof (entry as Record<string, unknown>).target === "number" &&
+        Number.isFinite((entry as Record<string, unknown>).target) &&
+        (((entry as Record<string, unknown>).comparison as string) === "atLeast" ||
+          ((entry as Record<string, unknown>).comparison as string) === "atMost")
+      );
+
+    const consequenceValid = (value: unknown): boolean =>
+      Array.isArray(value) &&
+      value.every(
+        (entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          typeof (entry as Record<string, unknown>).resource === "string" &&
+          typeof (entry as Record<string, unknown>).amount === "number" &&
+          Number.isFinite((entry as Record<string, unknown>).amount)
+      );
+
+    const milestoneValid =
+      Array.isArray(milestones) &&
+      milestones.every(
+        (entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          typeof (entry as Record<string, unknown>).order === "number" &&
+          Number.isFinite((entry as Record<string, unknown>).order) &&
+          typeof (entry as Record<string, unknown>).day === "number" &&
+          Number.isFinite((entry as Record<string, unknown>).day) &&
+          typeof (entry as Record<string, unknown>).label === "string" &&
+          typeof (entry as Record<string, unknown>).description === "string"
+      );
+
+    return (
+      typeof id === "string" &&
+      typeof label === "string" &&
+      typeof description === "string" &&
+      typeof prestigeReward === "number" &&
+      Number.isFinite(prestigeReward) &&
+      typeof durationDays === "number" &&
+      Number.isFinite(durationDays) &&
+      requirementValid &&
+      consequenceValid(rewards) &&
+      consequenceValid(penalties) &&
+      milestoneValid
+    );
+  }
+}
+
+const runSystem = new RunSystem();
+
+export default runSystem;

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -1,0 +1,106 @@
+import type { MandateConsequence, MandateRequirement, RoyalMandate } from "./game";
+
+/**
+ * Represents a noteworthy checkpoint communicated to the player while pursuing a mandate.
+ */
+export interface MandateMilestone {
+  /** Sequential order of the milestone within the mandate timeline. */
+  readonly order: number;
+  /** In-game day when the milestone should surface. */
+  readonly day: number;
+  /** Concise description displayed in UI timelines. */
+  readonly label: string;
+  /** Detailed guidance for the player. */
+  readonly description: string;
+}
+
+/**
+ * Visualised data for presenting a royal mandate as a selectable card.
+ */
+export interface MandateCardView {
+  /** Identifier mapping back to the underlying mandate definition. */
+  readonly id: string;
+  /** Display title for the card. */
+  readonly title: string;
+  /** Flavour summary conveying the royal directive. */
+  readonly summary: string;
+  /** Prestige gained when the mandate is honoured. */
+  readonly prestigeReward: number;
+  /** Number of in-game days granted to satisfy the mandate. */
+  readonly durationDays: number;
+  /** Data-driven requirements that must be met to succeed. */
+  readonly requirements: MandateRequirement[];
+  /** Rewards applied upon successful completion. */
+  readonly rewards: MandateConsequence[];
+  /** Penalties applied on failure. */
+  readonly penalties: MandateConsequence[];
+  /** Concise mechanical overview derived from rewards and penalties. */
+  readonly effectSummary: string;
+  /** Generated milestone timeline used to pace reminders. */
+  readonly milestones: MandateMilestone[];
+  /** Clone of the originating mandate definition for downstream systems. */
+  readonly definition: RoyalMandate;
+}
+
+/**
+ * Modifier applied to the active roguelike run sourced from a selected mandate.
+ */
+export interface RunModifier {
+  /** Unique identifier referencing the modifier source. */
+  readonly id: string;
+  /** Human readable label surfaced in tooltips. */
+  readonly label: string;
+  /** Concise description summarising gameplay impact. */
+  readonly description: string;
+  /** Prestige payout granted when the modifier objective is completed. */
+  readonly prestigeReward: number;
+  /** Duration window communicated to other systems. */
+  readonly durationDays: number;
+  /** Structured requirement data. */
+  readonly requirements: MandateRequirement[];
+  /** Structured reward entries to apply on success. */
+  readonly rewards: MandateConsequence[];
+  /** Structured penalties to apply on failure. */
+  readonly penalties: MandateConsequence[];
+  /** Timeline cues for reminder scheduling. */
+  readonly milestones: MandateMilestone[];
+}
+
+/**
+ * Current run metadata tracked by the {@link RunSystem}.
+ */
+export interface ActiveRunState {
+  /** Generated identifier for the active run. */
+  readonly runId: string;
+  /** Seed controlling deterministic systems. */
+  readonly seed: number;
+  /** Epoch timestamp when the run started. */
+  readonly startedAt: number;
+  /** Selected modifiers influencing the run. */
+  readonly modifiers: RunModifier[];
+}
+
+/**
+ * Possible outcomes when resolving a run.
+ */
+export type RunOutcome = "victory" | "defeat";
+
+/**
+ * Persisted summary of a completed run used for legacy calculations.
+ */
+export interface RunSummary {
+  /** Identifier referencing the associated run. */
+  readonly runId: string;
+  /** Seed originally used when the run started. */
+  readonly seed: number;
+  /** Final outcome achieved by the player. */
+  readonly outcome: RunOutcome;
+  /** Calculated legacy points awarded to the dynasty. */
+  readonly legacyPoints: number;
+  /** Epoch timestamp capturing when the run concluded. */
+  readonly completedAt: number;
+  /** Modifiers that shaped the run. */
+  readonly modifiers: RunModifier[];
+  /** Notes summarising the legacy impact for the next generation. */
+  readonly notes: string[];
+}


### PR DESCRIPTION
## Summary
- add a mandate system to load royal mandates and generate card views with milestones
- introduce a run system that tracks active modifiers, computes legacy points, and stores summaries
- extend the main menu with succession selection and settlement overlays powered by the new systems

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4cd08c7e0832ebd04e71ccf7450d1