### PR TITLE
Implement dragon intel progression and dragon lair battle

### DIFF
--- a/src/data/DragonIntel.ts
+++ b/src/data/DragonIntel.ts
@@ -1,0 +1,33 @@
+import type { DragonIntelState } from "../types/state";
+
+/**
+ * Constant ranges describing dragon intelligence rewards for different encounter types.
+ */
+export const DRAGON_INTEL_SOURCES = {
+  /** Intel awarded for elite threat encounters. */
+  elite: { min: 2, max: 4 },
+  /** Intel awarded for delving ruin sites. */
+  ruins: { min: 1, max: 3 },
+  /** Intel awarded when a site is both elite and ruins flavoured. */
+  eliteRuins: { min: 3, max: 5 }
+} as const;
+
+/**
+ * Upper bound for accumulated dragon intelligence used to cap storage.
+ */
+export const DRAGON_INTEL_MAX = 999;
+
+/**
+ * Threshold where accumulated intel reveals the dragon's lair.
+ */
+export const DRAGON_INTEL_THRESHOLD = 12;
+
+/**
+ * Produces the default persisted state for dragon intelligence progress.
+ */
+export const createDefaultDragonIntelState = (): DragonIntelState => ({
+  current: 0,
+  threshold: DRAGON_INTEL_THRESHOLD,
+  lairUnlocked: false
+});
+

--- a/src/data/GameStateFactory.ts
+++ b/src/data/GameStateFactory.ts
@@ -1,8 +1,9 @@
-import type { InventoryItem, InventoryState, KnightRecord, KnightsState } from "../types/state";
+import type { DragonIntelState, InventoryItem, InventoryState, KnightRecord, KnightsState } from "../types/state";
 import type { EventLogEntry } from "../types/events";
 import type { ResourceSnapshot } from "../systems/ResourceManager";
 import type { GameState, QueueItemState } from "../types/state";
 import { cloneBuildingState, createDefaultBuildingState } from "./BuildingState";
+import { createDefaultDragonIntelState } from "./DragonIntel";
 
 export const GAME_STATE_VERSION = 1;
 
@@ -34,6 +35,12 @@ const createDefaultKnightsState = (): KnightsState => ({
 });
 
 const createDefaultEventLog = (): EventLogEntry[] => [];
+
+const cloneDragonIntelState = (state: DragonIntelState): DragonIntelState => ({
+  current: state.current,
+  threshold: state.threshold,
+  lairUnlocked: state.lairUnlocked
+});
 
 const cloneEventLogEntry = (entry: EventLogEntry): EventLogEntry => ({
   ...entry,
@@ -80,6 +87,7 @@ export const createDefaultGameState = (): GameState => ({
   inventory: cloneInventoryState(DEFAULT_INVENTORY),
   knights: createDefaultKnightsState(),
   buildings: createDefaultBuildingState(),
+  dragonIntel: createDefaultDragonIntelState(),
   eventSeed: Math.floor(Date.now() % 1_000_000_000) + 7,
   pendingEventId: undefined,
   eventLog: createDefaultEventLog()
@@ -95,6 +103,7 @@ export const cloneGameState = (state: GameState): GameState => ({
   inventory: cloneInventoryState(state.inventory),
   knights: cloneKnightsState(state.knights),
   buildings: cloneBuildingState(state.buildings),
+  dragonIntel: cloneDragonIntelState(state.dragonIntel),
   eventSeed: state.eventSeed,
   pendingEventId: state.pendingEventId,
   eventLog: state.eventLog.map(cloneEventLogEntry)

--- a/src/data/MapNodes.ts
+++ b/src/data/MapNodes.ts
@@ -1,4 +1,13 @@
-﻿import type { BiomeType, ThreatLevel } from "../types/quests";
+import type { BiomeType, ThreatLevel } from "../types/quests";
+
+/** Identifiers describing gameplay relevant traits for map nodes. */
+export type MapNodeTag = "elite" | "ruins" | "dragonLair";
+
+/** Unlock requirements for interacting with special map nodes. */
+export interface MapNodeUnlockCondition {
+  /** Type of progression gate required. */
+  readonly type: "dragonIntel";
+}
 
 /**
  * Describes an interactive strategic node rendered on the world map.
@@ -19,6 +28,10 @@ export interface MapNodeDefinition {
     readonly x: number;
     readonly y: number;
   };
+  /** Optional gameplay tags used to adjust encounter generation. */
+  readonly tags?: ReadonlyArray<MapNodeTag>;
+  /** Optional unlock gating for special content. */
+  readonly unlockCondition?: MapNodeUnlockCondition;
 }
 
 /**
@@ -31,7 +44,8 @@ export const MAP_NODE_DEFINITIONS: ReadonlyArray<MapNodeDefinition> = [
     description: "Jagged peaks hiding wyvern nests and lost mining expeditions.",
     biome: "Highlands",
     defaultThreat: "Moderate",
-    position: { x: 0.22, y: 0.48 }
+    position: { x: 0.22, y: 0.48 },
+    tags: ["elite"]
   },
   {
     id: "ashen-marsh",
@@ -47,7 +61,8 @@ export const MAP_NODE_DEFINITIONS: ReadonlyArray<MapNodeDefinition> = [
     description: "Ancient forest groves patrolled by sentient treants.",
     biome: "Forest",
     defaultThreat: "Severe",
-    position: { x: 0.68, y: 0.38 }
+    position: { x: 0.68, y: 0.38 },
+    tags: ["elite"]
   },
   {
     id: "tidebreak-cliffs",
@@ -63,6 +78,26 @@ export const MAP_NODE_DEFINITIONS: ReadonlyArray<MapNodeDefinition> = [
     description: "Collapsed citadel where volcanic vents sear the sky.",
     biome: "Volcanic",
     defaultThreat: "Catastrophic",
-    position: { x: 0.33, y: 0.25 }
+    position: { x: 0.33, y: 0.25 },
+    tags: ["elite"]
+  },
+  {
+    id: "shattered-reliquary",
+    label: "Shattered Reliquary",
+    description: "Crumbled sanctum littered with arcane wards and spectral guardians.",
+    biome: "Ruins",
+    defaultThreat: "Severe",
+    position: { x: 0.58, y: 0.18 },
+    tags: ["ruins"]
+  },
+  {
+    id: "dragon-lair",
+    label: "巨龍巢穴",
+    description: "Ancient caldera where the wyrm hoards its tribute beneath molten stone.",
+    biome: "Volcanic",
+    defaultThreat: "Catastrophic",
+    position: { x: 0.12, y: 0.18 },
+    tags: ["dragonLair"],
+    unlockCondition: { type: "dragonIntel" }
   }
 ] as const;

--- a/src/scenes/CastleScene.ts
+++ b/src/scenes/CastleScene.ts
@@ -174,6 +174,7 @@ export default class CastleScene extends Phaser.Scene {
     inventorySystem.initialize(state.inventory);
     knightManager.initialize(state.knights);
     buildingSystem.initialize(state.buildings);
+    expeditionSystem.initializeDragonIntel(state.dragonIntel);
     eventSystem.initialize({
       eventSeed: state.eventSeed,
       pendingEventId: state.pendingEventId,
@@ -906,6 +907,10 @@ export default class CastleScene extends Phaser.Scene {
     const seed = this.computeExpeditionSeed(quest.id);
     const result = expeditionSystem.resolveExpedition(partyIds, node, seed);
     const summary = this.formatExpeditionResult(result, quest);
+    this.currentState = {
+      ...this.currentState,
+      dragonIntel: expeditionSystem.getDragonIntelState()
+    };
 
     this.lastExpeditionSummary = summary;
     if (this.dispatchResultText) {
@@ -956,6 +961,15 @@ export default class CastleScene extends Phaser.Scene {
 
     if (result.intel) {
       lines.push(`Intel: ${result.intel.description}`);
+      const gained = result.intel.dragonIntelGained;
+      const intelSummary =
+        gained > 0
+          ? `Dragon Intel +${gained} (Total ${result.intel.totalDragonIntel}/${result.intel.threshold})`
+          : `Dragon Intel ${result.intel.totalDragonIntel}/${result.intel.threshold}`;
+      lines.push(intelSummary);
+      if (result.intel.thresholdReached) {
+        lines.push("Dragon Lair sighted! Final assault unlocked.");
+      }
     }
 
     return lines.join("\n");
@@ -1009,6 +1023,7 @@ export default class CastleScene extends Phaser.Scene {
       queue: this.currentState.queue.map((item) => ({ ...item })),
       knights: knightManager.getState(),
       buildings: buildingSystem.getState(),
+      dragonIntel: expeditionSystem.getDragonIntelState(),
       eventSeed: eventSnapshot.eventSeed,
       pendingEventId: eventSnapshot.pendingEventId,
       eventLog: eventSnapshot.eventLog.map((entry) => this.cloneEventLogEntry(entry))

--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -1,9 +1,16 @@
-﻿import Phaser from "phaser";
+import Phaser from "phaser";
 
 import { MAP_NODE_DEFINITIONS, type MapNodeDefinition } from "../data/MapNodes";
 import { SceneKeys } from "../data/SceneKeys";
 import questManager from "../systems/QuestManager";
+import expeditionSystem from "../systems/ExpeditionSystem";
+import knightManager from "../systems/KnightManager";
+import bossBattle from "../systems/BossBattle";
+import runSystem from "../systems/RunSystem";
+import RNG from "../utils/RNG";
 import type { QuestRecord } from "../types/quests";
+import type { KnightRecord } from "../types/state";
+import type { BossBattleReport } from "../types/boss";
 
 interface MapSceneData {
   /** Optional scene key that should resume when the map closes. */
@@ -20,6 +27,7 @@ export default class MapScene extends Phaser.Scene {
   private popupOverlay: Phaser.GameObjects.Rectangle | null;
   private popupContainer: Phaser.GameObjects.Container | null;
   private questSummaryText: Phaser.GameObjects.Text | null;
+  private intelStatusText: Phaser.GameObjects.Text | null;
 
   public constructor() {
     super(MapScene.KEY);
@@ -27,6 +35,7 @@ export default class MapScene extends Phaser.Scene {
     this.popupOverlay = null;
     this.popupContainer = null;
     this.questSummaryText = null;
+    this.intelStatusText = null;
   }
 
   /**
@@ -43,8 +52,10 @@ export default class MapScene extends Phaser.Scene {
     this.cameras.main.setBackgroundColor(0x0f172a);
     this.drawBackdrop();
     this.drawNodes();
+    this.drawIntelStatus();
     this.drawQuestSummary();
     this.drawReturnButton();
+    this.updateIntelStatus();
   }
 
   private drawBackdrop(): void {
@@ -79,43 +90,88 @@ export default class MapScene extends Phaser.Scene {
 
   private drawNodes(): void {
     const { width, height } = this.scale;
+    const intelState = expeditionSystem.getDragonIntelState();
 
     MAP_NODE_DEFINITIONS.forEach((node) => {
       const x = node.position.x * width;
       const y = node.position.y * height;
-      const circleRadius = 26;
+      const circleRadius = this.isDragonLair(node) ? 32 : 26;
+      const unlocked = this.isNodeUnlocked(node, intelState);
+
+      const baseFill = this.isDragonLair(node)
+        ? unlocked
+          ? 0xf97316
+          : 0x475569
+        : 0x3b82f6;
+      const baseStroke = this.isDragonLair(node) ? 0xfacc15 : 0x93c5fd;
 
       const nodeGraphics = this.add.graphics({ x, y });
-      nodeGraphics.fillStyle(0x3b82f6, 1);
-      nodeGraphics.fillCircle(0, 0, circleRadius);
-      nodeGraphics.lineStyle(3, 0x93c5fd, 1);
-      nodeGraphics.strokeCircle(0, 0, circleRadius);
-      nodeGraphics.setInteractive({ hitArea: new Phaser.Geom.Circle(0, 0, circleRadius), hitAreaCallback: Phaser.Geom.Circle.Contains, useHandCursor: true });
-      nodeGraphics.on("pointerover", () => {
-        nodeGraphics.clear();
-        nodeGraphics.fillStyle(0x60a5fa, 1);
-        nodeGraphics.fillCircle(0, 0, circleRadius);
-        nodeGraphics.lineStyle(3, 0xffffff, 1);
-        nodeGraphics.strokeCircle(0, 0, circleRadius);
-      });
-      nodeGraphics.on("pointerout", () => {
-        nodeGraphics.clear();
-        nodeGraphics.fillStyle(0x3b82f6, 1);
-        nodeGraphics.fillCircle(0, 0, circleRadius);
-        nodeGraphics.lineStyle(3, 0x93c5fd, 1);
-        nodeGraphics.strokeCircle(0, 0, circleRadius);
-      });
-      nodeGraphics.on("pointerup", () => {
-        this.openQuestPopup(node);
+      this.renderNodeCircle(nodeGraphics, circleRadius, baseFill, baseStroke);
+      nodeGraphics.setInteractive({
+        hitArea: new Phaser.Geom.Circle(0, 0, circleRadius),
+        hitAreaCallback: Phaser.Geom.Circle.Contains,
+        useHandCursor: true
       });
 
-      const label = this.add.text(x, y + circleRadius + 6, node.label, {
+      nodeGraphics.on("pointerover", () => {
+        const hoverFill = this.isDragonLair(node)
+          ? unlocked
+            ? 0xfb923c
+            : 0x64748b
+          : 0x60a5fa;
+        this.renderNodeCircle(nodeGraphics, circleRadius, hoverFill, 0xffffff);
+      });
+      nodeGraphics.on("pointerout", () => {
+        this.renderNodeCircle(nodeGraphics, circleRadius, baseFill, baseStroke);
+      });
+      nodeGraphics.on("pointerup", () => {
+        if (this.isDragonLair(node)) {
+          this.openDragonLairPopup(node);
+        } else {
+          this.openQuestPopup(node);
+        }
+      });
+
+      if (this.isDragonLair(node) && !unlocked) {
+        const lock = this.add.text(x, y, "🔒", {
+          fontFamily: "Segoe UI, sans-serif",
+          fontSize: "22px",
+          color: "#f8fafc"
+        });
+        lock.setOrigin(0.5);
+      }
+
+      const labelText = this.isDragonLair(node) && !unlocked ? `${node.label} (Locked)` : node.label;
+      const label = this.add.text(x, y + circleRadius + 6, labelText, {
         fontFamily: "Segoe UI, sans-serif",
         fontSize: "18px",
         color: "#e2e8f0"
       });
       label.setOrigin(0.5, 0);
     });
+  }
+
+  private renderNodeCircle(
+    graphics: Phaser.GameObjects.Graphics,
+    radius: number,
+    fillColor: number,
+    borderColor: number
+  ): void {
+    graphics.clear();
+    graphics.fillStyle(fillColor, 1);
+    graphics.fillCircle(0, 0, radius);
+    graphics.lineStyle(3, borderColor, 1);
+    graphics.strokeCircle(0, 0, radius);
+  }
+
+  private drawIntelStatus(): void {
+    const { width } = this.scale;
+    this.intelStatusText = this.add.text(width - 24, 24, "", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      color: "#facc15"
+    });
+    this.intelStatusText.setOrigin(1, 0);
   }
 
   private drawQuestSummary(): void {
@@ -136,7 +192,7 @@ export default class MapScene extends Phaser.Scene {
 
     const button = this.add.rectangle(0, 0, buttonWidth, buttonHeight, 0x0f172a, 1);
     button.setOrigin(0, 0);
-    button.setPosition(this.scale.width - buttonWidth - 24, 24);
+    button.setPosition(this.scale.width - buttonWidth - 24, this.scale.height - buttonHeight - 24);
     button.setStrokeStyle(2, 0x38bdf8, 0.8);
     button.setInteractive({ useHandCursor: true });
     button.on("pointerover", () => button.setFillStyle(0x1d4ed8, 1));
@@ -150,6 +206,17 @@ export default class MapScene extends Phaser.Scene {
     });
     label.setOrigin(0.5);
     label.setDepth(button.depth + 1);
+  }
+
+  private updateIntelStatus(): void {
+    if (!this.intelStatusText) {
+      return;
+    }
+
+    const state = expeditionSystem.getDragonIntelState();
+    const status = state.lairUnlocked ? "Lair Unlocked" : "Locked";
+    this.intelStatusText.setText(`Dragon Intel ${state.current}/${state.threshold} · ${status}`);
+    this.intelStatusText.setColor(state.lairUnlocked ? "#facc15" : "#94a3b8");
   }
 
   private openQuestPopup(node: MapNodeDefinition): void {
@@ -214,6 +281,88 @@ export default class MapScene extends Phaser.Scene {
     this.popupContainer = container;
   }
 
+  private openDragonLairPopup(node: MapNodeDefinition): void {
+    this.closeQuestPopup();
+    this.popupOverlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x020617, 0.7);
+    this.popupOverlay.setOrigin(0, 0);
+    this.popupOverlay.setDepth(20);
+    this.popupOverlay.setInteractive();
+
+    const container = this.add.container(this.scale.width / 2, this.scale.height / 2);
+    container.setDepth(21);
+
+    const width = 420;
+    const height = 300;
+    const background = this.add.rectangle(0, 0, width, height, 0x111827, 0.96);
+    background.setOrigin(0.5);
+    background.setStrokeStyle(2, 0xf97316, 0.9);
+
+    const title = this.add.text(0, -height / 2 + 36, node.label, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "24px",
+      fontStyle: "bold",
+      color: "#fef3c7"
+    });
+    title.setOrigin(0.5, 0.5);
+
+    const intelState = expeditionSystem.getDragonIntelState();
+    const unlocked = this.isNodeUnlocked(node, intelState);
+    const statusLine = unlocked ? "Assault plans ready." : "Insufficient dragon intel.";
+
+    const intelText = this.add.text(-width / 2 + 24, -24, `Intel ${intelState.current}/${intelState.threshold}`, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "18px",
+      color: unlocked ? "#fde68a" : "#fca5a5"
+    });
+
+    const description = this.add.text(-width / 2 + 24, 12, node.description, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "16px",
+      color: "#e2e8f0",
+      wordWrap: { width: width - 48 }
+    });
+
+    const statusText = this.add.text(-width / 2 + 24, 96, statusLine, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "16px",
+      color: unlocked ? "#bbf7d0" : "#fca5a5"
+    });
+
+    let actionButton: Phaser.GameObjects.Container | null = null;
+    if (unlocked) {
+      actionButton = this.buildPrimaryButton(0, height / 2 - 60, width - 60, 48, "Launch Final Assault", () => {
+        this.launchDragonLairAssault(node);
+      });
+    } else {
+      const disabled = this.add.rectangle(0, height / 2 - 60, width - 60, 48, 0x1f2937, 0.9);
+      disabled.setOrigin(0.5);
+      disabled.setStrokeStyle(2, 0x4b5563, 0.8);
+      const label = this.add.text(disabled.x, disabled.y, "Gather More Intel", {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "18px",
+        color: "#94a3b8"
+      });
+      label.setOrigin(0.5);
+      container.add(disabled);
+      container.add(label);
+    }
+
+    const closeButton = this.add.text(width / 2 - 26, -height / 2 + 24, "X", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "20px",
+      color: "#94a3b8"
+    });
+    closeButton.setOrigin(0.5);
+    closeButton.setInteractive({ useHandCursor: true });
+    closeButton.on("pointerup", () => this.closeQuestPopup());
+
+    container.add([background, title, intelText, description, statusText, closeButton]);
+    if (actionButton) {
+      container.add(actionButton);
+    }
+    this.popupContainer = container;
+  }
+
   private buildPrimaryButton(
     x: number,
     y: number,
@@ -237,7 +386,11 @@ export default class MapScene extends Phaser.Scene {
 
     buttonContainer.add([background, text]);
     buttonContainer.setSize(width, height);
-    buttonContainer.setInteractive({ hitArea: new Phaser.Geom.Rectangle(-width / 2, -height / 2, width, height), hitAreaCallback: Phaser.Geom.Rectangle.Contains, useHandCursor: true });
+    buttonContainer.setInteractive({
+      hitArea: new Phaser.Geom.Rectangle(-width / 2, -height / 2, width, height),
+      hitAreaCallback: Phaser.Geom.Rectangle.Contains,
+      useHandCursor: true
+    });
     buttonContainer.on("pointerover", () => background.setFillStyle(0x2563eb, 1));
     buttonContainer.on("pointerout", () => background.setFillStyle(0x1d4ed8, 1));
     buttonContainer.on("pointerup", () => {
@@ -264,6 +417,139 @@ export default class MapScene extends Phaser.Scene {
       feedback.destroy();
       this.closeQuestPopup();
     });
+  }
+
+  private launchDragonLairAssault(node: MapNodeDefinition): void {
+    if (!this.popupContainer) {
+      return;
+    }
+
+    const roster = knightManager.getRoster();
+    const strikeTeam = this.selectStrikeTeam(roster);
+    if (strikeTeam.length === 0) {
+      const warning = this.add.text(0, 120, "No healthy knights available for the assault.", {
+        fontFamily: "Segoe UI, sans-serif",
+        fontSize: "16px",
+        color: "#f87171",
+        wordWrap: { width: 360 }
+      });
+      warning.setOrigin(0.5);
+      this.popupContainer.add(warning);
+      this.time.delayedCall(1600, () => warning.destroy());
+      return;
+    }
+
+    const rngSeed = Math.floor(Date.now() % 2147483647) + strikeTeam.length * 17;
+    const report = bossBattle.simulate(strikeTeam, new RNG(rngSeed));
+    this.presentBossBattleResult(report, node.label);
+  }
+
+  private selectStrikeTeam(roster: ReadonlyArray<KnightRecord>): KnightRecord[] {
+    return [...roster]
+      .sort((a, b) => this.evaluateKnightScore(b) - this.evaluateKnightScore(a))
+      .slice(0, 6);
+  }
+
+  private evaluateKnightScore(knight: KnightRecord): number {
+    const { might, agility, willpower } = knight.attributes;
+    const base = might * 1.1 + agility + willpower * 0.95;
+    const fatiguePenalty = 1 - Math.min(0.6, knight.fatigue / 150);
+    const injuryPenalty = 1 - Math.min(0.7, knight.injury / 130);
+    return base * fatiguePenalty * injuryPenalty;
+  }
+
+  private presentBossBattleResult(report: BossBattleReport, lairLabel: string): void {
+    this.closeQuestPopup();
+
+    this.popupOverlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x020617, 0.78);
+    this.popupOverlay.setOrigin(0, 0);
+    this.popupOverlay.setDepth(22);
+    this.popupOverlay.setInteractive();
+
+    const container = this.add.container(this.scale.width / 2, this.scale.height / 2);
+    container.setDepth(23);
+
+    const width = 520;
+    const height = 360;
+    const background = this.add.rectangle(0, 0, width, height, 0x0f172a, 0.97);
+    background.setOrigin(0.5);
+    background.setStrokeStyle(2, report.outcome === "victory" ? 0x22c55e : 0xef4444, 0.9);
+
+    const title = this.add.text(0, -height / 2 + 32, `${lairLabel} Battle Report`, {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "24px",
+      fontStyle: "bold",
+      color: "#f8fafc"
+    });
+    title.setOrigin(0.5, 0.5);
+
+    const outcomeText = this.add.text(0, title.y + 40, report.outcome === "victory" ? "Victory" : "Defeat", {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "20px",
+      color: report.outcome === "victory" ? "#bbf7d0" : "#fca5a5"
+    });
+    outcomeText.setOrigin(0.5, 0.5);
+
+    const summaryLines: string[] = [];
+    summaryLines.push(`Total Damage Dealt: ${Math.round(report.totalDamageDealt)}`);
+    summaryLines.push(`Total Damage Taken: ${Math.round(report.totalDamageTaken)}`);
+    summaryLines.push(`Survivors: ${report.survivingKnights.length}`);
+    if (report.defeatedKnights.length > 0) {
+      summaryLines.push(`Fallen: ${report.defeatedKnights.join(", ")}`);
+    }
+
+    summaryLines.push("Phases:");
+    report.phases.forEach((phase) => {
+      summaryLines.push(
+        ` - ${phase.phase} (${phase.rounds} rounds, damage dealt ${Math.round(phase.damageDealt)}, hazard hits ${phase.hazardEvents.length})`
+      );
+    });
+
+    const hazardEvents = report.phases.flatMap((phase) => phase.hazardEvents);
+    if (hazardEvents.length > 0) {
+      summaryLines.push("Hazards:");
+      hazardEvents.slice(0, 3).forEach((event) => {
+        summaryLines.push(
+          ` - Round ${event.round} ${event.type} dealt ${Math.round(event.totalDamage)} to ${event.affected.length} knights`
+        );
+      });
+      if (hazardEvents.length > 3) {
+        summaryLines.push(` - ${hazardEvents.length - 3} additional hazard events`);
+      }
+    }
+
+    const summaryText = this.add.text(-width / 2 + 24, outcomeText.y + 26, summaryLines.join("\n"), {
+      fontFamily: "Segoe UI, sans-serif",
+      fontSize: "16px",
+      color: "#e2e8f0",
+      wordWrap: { width: width - 48 }
+    });
+    summaryText.setOrigin(0, 0);
+
+    const concludeButton = this.buildPrimaryButton(0, height / 2 - 50, width - 80, 50, "Conclude Succession", () => {
+      this.finalizeBossBattle(report);
+    });
+
+    container.add([background, title, outcomeText, summaryText, concludeButton]);
+    this.popupContainer = container;
+  }
+
+  private finalizeBossBattle(report: BossBattleReport): void {
+    runSystem.endRun(report.outcome);
+    expeditionSystem.resetDragonIntel();
+    this.updateIntelStatus();
+    this.closeQuestPopup();
+
+    if (this.scene.isActive(SceneKeys.UI)) {
+      this.scene.stop(SceneKeys.UI);
+    }
+
+    if (this.scene.isActive(this.returnSceneKey)) {
+      this.scene.stop(this.returnSceneKey);
+    }
+
+    this.scene.stop(MapScene.KEY);
+    this.scene.start(SceneKeys.MainMenu);
   }
 
   private closeQuestPopup(): void {
@@ -313,11 +599,20 @@ export default class MapScene extends Phaser.Scene {
 
     this.scene.stop(MapScene.KEY);
   }
+
+  private isDragonLair(node: MapNodeDefinition): boolean {
+    return (node.tags ?? []).includes("dragonLair");
+  }
+
+  private isNodeUnlocked(node: MapNodeDefinition, intelState = expeditionSystem.getDragonIntelState()): boolean {
+    if (!this.isDragonLair(node)) {
+      return true;
+    }
+
+    if (!node.unlockCondition) {
+      return true;
+    }
+
+    return intelState.lairUnlocked;
+  }
 }
-
-
-
-
-
-
-

--- a/src/systems/BattleSimulator.ts
+++ b/src/systems/BattleSimulator.ts
@@ -7,7 +7,7 @@ import type {
   InjuryReport,
   LootResult,
   LootEntry,
-  IntelReport
+  IntelDiscovery
 } from "../types/expeditions";
 import RNG from "../utils/RNG";
 
@@ -139,7 +139,7 @@ class BattleSimulator {
   /**
    * Determines whether intel is recovered after the expedition.
    */
-  public maybeGainIntel(encounter: EncounterDefinition, rng: RNG): IntelReport | null {
+  public maybeGainIntel(encounter: EncounterDefinition, rng: RNG): IntelDiscovery | null {
     if (encounter.intelChance <= 0) {
       return null;
     }
@@ -157,9 +157,21 @@ class BattleSimulator {
     ];
     const detail = descriptors[Math.floor(rng.next() * descriptors.length)] ?? "gained intelligence";
 
+    const dragonIntelRange = encounter.dragonIntelRange;
+    let dragonIntelGained = 0;
+    if (dragonIntelRange) {
+      const min = Math.max(0, dragonIntelRange.min);
+      const span = Math.max(0, dragonIntelRange.max - min);
+      dragonIntelGained = Math.round(min + rng.next() * span);
+      if (dragonIntelGained < min) {
+        dragonIntelGained = min;
+      }
+    }
+
     return {
-      description: `${encounter.name}: ${detail}`
-    } satisfies IntelReport;
+      description: `${encounter.name}: ${detail}`,
+      dragonIntelGained
+    } satisfies IntelDiscovery;
   }
 
   private calculatePartyPower(party: ReadonlyArray<KnightRecord>): number {

--- a/src/systems/BossBattle.ts
+++ b/src/systems/BossBattle.ts
@@ -1,0 +1,381 @@
+import type { KnightRecord } from "../types/state";
+import type { RunOutcome } from "../types/run";
+import type {
+  BossBattleReport,
+  BossHazardReport,
+  BossHazardType,
+  BossPhaseName,
+  BossPhaseReport
+} from "../types/boss";
+import RNG from "../utils/RNG";
+
+interface PhaseConfig {
+  readonly name: BossPhaseName;
+  readonly baseHealth: number;
+  readonly attackMultiplier: number;
+  readonly retaliationDamage: number;
+  readonly hazardChance: number;
+}
+
+interface ActiveHazard {
+  readonly type: BossHazardType;
+  remaining: number;
+  intensity: number;
+}
+
+const PHASE_SEQUENCE: ReadonlyArray<PhaseConfig> = [
+  { name: "Scaled", baseHealth: 320, attackMultiplier: 0.26, retaliationDamage: 38, hazardChance: 0.35 },
+  { name: "Wounded", baseHealth: 260, attackMultiplier: 0.29, retaliationDamage: 52, hazardChance: 0.4 },
+  { name: "Rage", baseHealth: 210, attackMultiplier: 0.33, retaliationDamage: 68, hazardChance: 0.45 }
+];
+
+const PROFESSION_RESISTANCE: Record<
+  KnightRecord["profession"],
+  { readonly lava: number; readonly acid: number }
+> = {
+  Guardian: { lava: 0.35, acid: 0.18 },
+  Lancer: { lava: 0.24, acid: 0.22 },
+  Spellblade: { lava: 0.4, acid: 0.36 },
+  Ranger: { lava: 0.18, acid: 0.28 },
+  Sentinel: { lava: 0.3, acid: 0.26 }
+};
+
+const MIN_SURVIVOR_HEALTH = 45;
+
+/**
+ * Simulates the multi-phase dragon confrontation including environmental hazards.
+ */
+class BossBattle {
+  /**
+   * Resolves the dragon fight using an abstract strike team representation.
+   */
+  public simulate(party: ReadonlyArray<KnightRecord>, rng: RNG): BossBattleReport {
+    if (party.length === 0) {
+      return {
+        outcome: "defeat",
+        phases: [],
+        totalDamageDealt: 0,
+        totalDamageTaken: 0,
+        survivingKnights: [],
+        defeatedKnights: []
+      } satisfies BossBattleReport;
+    }
+
+    const knightMap = new Map<string, KnightRecord>();
+    const knightHealth = new Map<string, number>();
+    party.forEach((knight) => {
+      knightMap.set(knight.id, knight);
+      knightHealth.set(knight.id, this.calculateKnightDurability(knight));
+    });
+
+    const survivingIds = new Set(party.map((knight) => knight.id));
+    const defeatedNames: string[] = [];
+    const phases: BossPhaseReport[] = [];
+    let totalDamageDealt = 0;
+    let totalDamageTaken = 0;
+    let outcome: RunOutcome = "victory";
+
+    for (const phase of PHASE_SEQUENCE) {
+      if (survivingIds.size === 0) {
+        outcome = "defeat";
+        break;
+      }
+
+      const phaseReport = this.resolvePhase(phase, survivingIds, knightMap, knightHealth, defeatedNames, rng);
+      phases.push(phaseReport);
+      totalDamageDealt += phaseReport.damageDealt;
+      totalDamageTaken += phaseReport.damageTaken;
+
+      if (survivingIds.size === 0) {
+        outcome = "defeat";
+        break;
+      }
+    }
+
+    const survivingNames = Array.from(survivingIds)
+      .map((id) => knightMap.get(id)?.name ?? id)
+      .filter((name) => name.length > 0);
+
+    return {
+      outcome,
+      phases,
+      totalDamageDealt,
+      totalDamageTaken,
+      survivingKnights: survivingNames,
+      defeatedKnights: defeatedNames
+    } satisfies BossBattleReport;
+  }
+
+  private resolvePhase(
+    phase: PhaseConfig,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    defeatedNames: string[],
+    rng: RNG
+  ): BossPhaseReport {
+    const hazardEvents: BossHazardReport[] = [];
+    const activeHazards: ActiveHazard[] = [];
+    let dragonHealth = phase.baseHealth + survivingIds.size * 22;
+    let rounds = 0;
+    let phaseDamageDealt = 0;
+    let phaseDamageTaken = 0;
+
+    while (dragonHealth > 0 && survivingIds.size > 0 && rounds < 14) {
+      rounds += 1;
+
+      phaseDamageTaken += this.applyHazards(
+        activeHazards,
+        phase,
+        survivingIds,
+        knightMap,
+        knightHealth,
+        defeatedNames,
+        hazardEvents,
+        rounds,
+        rng
+      );
+
+      if (survivingIds.size === 0) {
+        break;
+      }
+
+      if (rng.next() < phase.hazardChance) {
+        phaseDamageTaken += this.spawnHazard(
+          activeHazards,
+          phase,
+          survivingIds,
+          knightMap,
+          knightHealth,
+          defeatedNames,
+          hazardEvents,
+          rounds,
+          rng
+        );
+      }
+
+      if (survivingIds.size === 0) {
+        break;
+      }
+
+      const strikeDamage = this.calculateStrikeDamage(phase, survivingIds, knightMap, knightHealth, rng);
+      dragonHealth -= strikeDamage;
+      phaseDamageDealt += strikeDamage;
+
+      if (dragonHealth <= 0) {
+        break;
+      }
+
+      const retaliation = this.calculateRetaliationDamage(phase, survivingIds.size, rng);
+      phaseDamageTaken += retaliation;
+      this.distributeRetaliationDamage(retaliation, survivingIds, knightMap, knightHealth, defeatedNames, rng);
+    }
+
+    return {
+      phase: phase.name,
+      rounds,
+      damageDealt: phaseDamageDealt,
+      damageTaken: phaseDamageTaken,
+      hazardEvents
+    } satisfies BossPhaseReport;
+  }
+
+  private calculateKnightDurability(knight: KnightRecord): number {
+    const { might, willpower } = knight.attributes;
+    const base = 140 + might * 0.9 + willpower * 0.8;
+    const fatiguePenalty = 1 - Math.min(0.55, knight.fatigue / 180);
+    const injuryPenalty = 1 - Math.min(0.65, knight.injury / 150);
+    return Math.max(MIN_SURVIVOR_HEALTH, base * fatiguePenalty * injuryPenalty);
+  }
+
+  private calculateStrikeDamage(
+    phase: PhaseConfig,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    rng: RNG
+  ): number {
+    let combinedPower = 0;
+    survivingIds.forEach((id) => {
+      const knight = knightMap.get(id);
+      if (!knight) {
+        return;
+      }
+      const { might, agility, willpower } = knight.attributes;
+      const stamina = (knightHealth.get(id) ?? 0) / 200;
+      const fatiguePenalty = 1 - Math.min(0.5, knight.fatigue / 160);
+      const injuryPenalty = 1 - Math.min(0.6, knight.injury / 140);
+      const professionBonus = this.professionBonus(knight.profession);
+      combinedPower += (might * 1.2 + agility * 1.05 + willpower * 0.95) * fatiguePenalty * injuryPenalty * professionBonus * (0.9 + stamina * 0.4);
+    });
+
+    const morale = 0.9 + rng.next() * 0.25;
+    const phaseModifier = 1 + PHASE_SEQUENCE.findIndex((entry) => entry.name === phase.name) * 0.08;
+    const damage = combinedPower * phase.attackMultiplier * morale * phaseModifier;
+    return Math.max(25, damage);
+  }
+
+  private professionBonus(profession: KnightRecord["profession"]): number {
+    switch (profession) {
+      case "Guardian":
+        return 1.12;
+      case "Lancer":
+        return 1.08;
+      case "Spellblade":
+        return 1.1;
+      case "Ranger":
+        return 1.04;
+      case "Sentinel":
+        return 1.06;
+      default:
+        return 1;
+    }
+  }
+
+  private calculateRetaliationDamage(phase: PhaseConfig, survivors: number, rng: RNG): number {
+    const base = phase.retaliationDamage * (0.9 + rng.next() * 0.4);
+    return base * Math.max(1, Math.sqrt(survivors));
+  }
+
+  private distributeRetaliationDamage(
+    totalDamage: number,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    defeatedNames: string[],
+    rng: RNG
+  ): void {
+    if (survivingIds.size === 0) {
+      return;
+    }
+
+    const perKnight = totalDamage / survivingIds.size;
+    const fallen: string[] = [];
+    survivingIds.forEach((id) => {
+      const knight = knightMap.get(id);
+      if (!knight) {
+        return;
+      }
+
+      const variance = 0.85 + rng.next() * 0.3;
+      const mitigation = Math.min(0.5, knight.attributes.might / 260);
+      const damage = Math.max(8, perKnight * variance * (1 - mitigation));
+      const current = knightHealth.get(id) ?? 0;
+      const remaining = current - damage;
+      knightHealth.set(id, remaining);
+
+      if (remaining <= 0) {
+        fallen.push(id);
+        defeatedNames.push(knight.name);
+      }
+    });
+    fallen.forEach((id) => {
+      survivingIds.delete(id);
+    });
+  }
+
+  private applyHazards(
+    hazards: ActiveHazard[],
+    phase: PhaseConfig,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    defeatedNames: string[],
+    log: BossHazardReport[],
+    round: number,
+    rng: RNG
+  ): number {
+    let accumulated = 0;
+    for (let index = hazards.length - 1; index >= 0; index -= 1) {
+      const hazard = hazards[index];
+      if (!hazard) {
+        continue;
+      }
+      const damage = this.applyHazardTick(
+        hazard.type,
+        hazard.intensity,
+        survivingIds,
+        knightMap,
+        knightHealth,
+        defeatedNames,
+        log,
+        round,
+        rng
+      );
+      accumulated += damage;
+      hazard.remaining -= 1;
+      hazard.intensity *= 0.8;
+      if (hazard.remaining <= 0) {
+        hazards.splice(index, 1);
+      }
+    }
+    return accumulated;
+  }
+
+  private spawnHazard(
+    hazards: ActiveHazard[],
+    phase: PhaseConfig,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    defeatedNames: string[],
+    log: BossHazardReport[],
+    round: number,
+    rng: RNG
+  ): number {
+    const type: BossHazardType = rng.next() < 0.5 ? "lava" : "acid";
+    const intensity = phase.retaliationDamage * (0.4 + rng.next() * 0.5);
+    const hazard: ActiveHazard = { type, remaining: 2, intensity };
+    hazards.push(hazard);
+    return this.applyHazardTick(type, intensity, survivingIds, knightMap, knightHealth, defeatedNames, log, round, rng);
+  }
+
+  private applyHazardTick(
+    type: BossHazardType,
+    intensity: number,
+    survivingIds: Set<string>,
+    knightMap: Map<string, KnightRecord>,
+    knightHealth: Map<string, number>,
+    defeatedNames: string[],
+    log: BossHazardReport[],
+    round: number,
+    rng: RNG
+  ): number {
+    if (survivingIds.size === 0) {
+      return 0;
+    }
+
+    let total = 0;
+    const affectedNames: string[] = [];
+    survivingIds.forEach((id) => {
+      const knight = knightMap.get(id);
+      if (!knight) {
+        return;
+      }
+
+      const resistance = PROFESSION_RESISTANCE[knight.profession] ?? { lava: 0.2, acid: 0.2 };
+      const baseMitigation = type === "lava" ? resistance.lava : resistance.acid;
+      const willpowerMitigation = Math.min(0.25, knight.attributes.willpower / 320);
+      const mitigation = Math.min(0.75, baseMitigation + willpowerMitigation);
+      const variance = 0.85 + rng.next() * 0.35;
+      const damage = Math.max(6, intensity * variance * (1 - mitigation));
+      const current = knightHealth.get(id) ?? 0;
+      const remaining = current - damage;
+      knightHealth.set(id, remaining);
+      total += damage;
+      affectedNames.push(knight.name);
+
+      if (remaining <= 0) {
+        survivingIds.delete(id);
+        defeatedNames.push(knight.name);
+      }
+    });
+
+    log.push({ round, type, totalDamage: total, affected: affectedNames });
+    return total;
+  }
+}
+
+const bossBattle = new BossBattle();
+
+export default bossBattle;

--- a/src/types/boss.ts
+++ b/src/types/boss.ts
@@ -1,0 +1,49 @@
+import type { RunOutcome } from "./run";
+
+/** Ordered phase names for the dragon confrontation. */
+export type BossPhaseName = "Scaled" | "Wounded" | "Rage";
+
+/** Environmental hazard types applied during the boss battle. */
+export type BossHazardType = "lava" | "acid";
+
+/** Summary of damage inflicted by an environmental hazard tick. */
+export interface BossHazardReport {
+  /** Round when the hazard dealt damage. */
+  readonly round: number;
+  /** Hazard element that triggered. */
+  readonly type: BossHazardType;
+  /** Aggregate damage inflicted across the strike team. */
+  readonly totalDamage: number;
+  /** Identifiers for knights affected in this tick. */
+  readonly affected: ReadonlyArray<string>;
+}
+
+/** Per-phase breakdown of the boss battle simulation. */
+export interface BossPhaseReport {
+  /** Named phase currently resolved. */
+  readonly phase: BossPhaseName;
+  /** Rounds elapsed within the phase. */
+  readonly rounds: number;
+  /** Total damage dealt to the dragon during the phase. */
+  readonly damageDealt: number;
+  /** Total damage received by the strike team during the phase. */
+  readonly damageTaken: number;
+  /** Logged hazard ticks encountered during the phase. */
+  readonly hazardEvents: ReadonlyArray<BossHazardReport>;
+}
+
+/** Result emitted by the {@link BossBattle} system. */
+export interface BossBattleReport {
+  /** Final outcome of the confrontation. */
+  readonly outcome: RunOutcome;
+  /** Ordered breakdown of each resolved phase. */
+  readonly phases: ReadonlyArray<BossPhaseReport>;
+  /** Aggregate damage dealt across all phases. */
+  readonly totalDamageDealt: number;
+  /** Aggregate damage sustained by the strike team. */
+  readonly totalDamageTaken: number;
+  /** Names of knights who survived the battle. */
+  readonly survivingKnights: ReadonlyArray<string>;
+  /** Names of knights who fell during the battle. */
+  readonly defeatedKnights: ReadonlyArray<string>;
+}

--- a/src/types/expeditions.ts
+++ b/src/types/expeditions.ts
@@ -19,6 +19,11 @@ export interface EncounterDefinition {
   readonly biome: BiomeType;
   /** Base probability (0-1) that intel is recovered. */
   readonly intelChance: number;
+  /** Optional intelligence reward range granted when the encounter is cleared. */
+  readonly dragonIntelRange?: {
+    readonly min: number;
+    readonly max: number;
+  };
   /** Loot table entries rolled after successful combat. */
   readonly lootTable: ReadonlyArray<LootEntry>;
 }
@@ -76,10 +81,24 @@ export interface GeneratedLoot {
 }
 
 /**
+ * Raw intel discovery emitted by the battle simulator before accumulation.
+ */
+export interface IntelDiscovery {
+  /** Narrative description of the findings. */
+  readonly description: string;
+  /** Dragon intelligence fragments awarded by this discovery. */
+  readonly dragonIntelGained: number;
+}
+
+/**
  * Optional intel gained from scouting or interactions.
  */
 export interface IntelReport {
   readonly description: string;
+  readonly dragonIntelGained: number;
+  readonly totalDragonIntel: number;
+  readonly threshold: number;
+  readonly thresholdReached: boolean;
 }
 
 /**

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -86,6 +86,18 @@ export interface InventoryState {
 }
 
 /**
+ * Tracks accumulated intelligence on the dragon's movements during a run.
+ */
+export interface DragonIntelState {
+  /** Current intel fragments recovered by expeditions. */
+  readonly current: number;
+  /** Threshold required to reveal the dragon's lair. */
+  readonly threshold: number;
+  /** Flag indicating whether the lair has been revealed on the world map. */
+  readonly lairUnlocked: boolean;
+}
+
+/**
  * Aggregated state for all knights managed by the player.
  */
 export interface KnightsState {
@@ -141,6 +153,8 @@ export interface GameState {
   knights: KnightsState;
   /** Player progression for castle infrastructure. */
   buildings: BuildingState;
+  /** Intelligence gathered toward locating the dragon's lair. */
+  dragonIntel: DragonIntelState;
   /** Seed controlling deterministic weekly narrative event rolls. */
   eventSeed: number;
   /** Identifier for the next forced narrative event, if scheduled. */


### PR DESCRIPTION
## Summary
- add persistent dragon intel tracking with new data defaults and SaveSystem integration
- update expeditions to grant intel from elite and ruin encounters and unlock dragon lair map node
- introduce boss battle simulation and map flow for final assault including run completion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d20bc3b4832ea545086696a51c00